### PR TITLE
[FIX/#6] color, font asset setting naming fix

### DIFF
--- a/app/src/main/java/com/sopt/clody/ui/theme/Color.kt
+++ b/app/src/main/java/com/sopt/clody/ui/theme/Color.kt
@@ -76,26 +76,4 @@ data class ClodyColors(
     val white: Color
 )
 
-val LocalClodyColors = staticCompositionLocalOf {
-    ClodyColors(
-        lightGreen = LightGreen,
-        mainGreen = MainGreen,
-        darkGreen = DarkGreen,
-        lightYellow = LightYellow,
-        mainYellow = MainYellow,
-        darkYellow = DarkYellow,
-        red = Red,
-        lightBlue = LightBlue,
-        blue = Blue,
-        gray01 = Gray01,
-        gray02 = Gray02,
-        gray03 = Gray03,
-        gray04 = Gray04,
-        gray05 = Gray05,
-        gray06 = Gray06,
-        gray07 = Gray07,
-        gray08 = Gray08,
-        gray09 = Gray09,
-        white = WHITE
-    )
-}
+val LocalClodyColors = staticCompositionLocalOf { defaultClodyColors }

--- a/app/src/main/java/com/sopt/clody/ui/theme/Theme.kt
+++ b/app/src/main/java/com/sopt/clody/ui/theme/Theme.kt
@@ -51,6 +51,6 @@ fun CLODYTheme(content: @Composable () -> Unit) {
                 WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true // 상태 표시줄 아이콘 색상을 항상 검정색으로 설정
             }
         }
-            MaterialTheme(content = content)
+        MaterialTheme(content = content)
     }
 }

--- a/app/src/main/java/com/sopt/clody/ui/theme/Theme.kt
+++ b/app/src/main/java/com/sopt/clody/ui/theme/Theme.kt
@@ -38,10 +38,10 @@ fun provideClodyColorsAndTypography(
 
 @Composable
 fun CLODYTheme(content: @Composable () -> Unit) {
-    val color = defaultClodyColors
+    val colors = defaultClodyColors
     val typography = defaultClodyTypography
 
-    provideClodyColorsAndTypography(color, typography) {
+    provideClodyColorsAndTypography(colors, typography) {
         val view = LocalView.current
         if (!view.isInEditMode) {
             // SideEffect를 사용하여 상태 표시줄의 색상을 설정

--- a/app/src/main/java/com/sopt/clody/ui/theme/Theme.kt
+++ b/app/src/main/java/com/sopt/clody/ui/theme/Theme.kt
@@ -1,15 +1,11 @@
 package com.sopt.clody.ui.theme
 
 import android.app.Activity
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
@@ -24,7 +20,7 @@ object ClodyTheme {
     val typography: ClodyTypography
         @Composable
         @ReadOnlyComposable
-        get() = LocalTypography.current
+        get() = LocalClodyTypography.current
 }
 
 @Composable
@@ -35,7 +31,7 @@ fun provideClodyColorsAndTypography(
 ) {
     CompositionLocalProvider(
         LocalClodyColors provides colors,
-        LocalTypography provides typography,
+        LocalClodyTypography provides typography,
         content = content,
     )
 }

--- a/app/src/main/java/com/sopt/clody/ui/theme/Type.kt
+++ b/app/src/main/java/com/sopt/clody/ui/theme/Type.kt
@@ -108,6 +108,4 @@ data class ClodyTypography(
     val detail2Medium: TextStyle
 )
 
-val LocalTypography = staticCompositionLocalOf {
-    defaultClodyTypography
-}
+val LocalClodyTypography = staticCompositionLocalOf { defaultClodyTypography }


### PR DESCRIPTION
## 📌 개요
- closed #6 

## ✨ 작업 내용
- [x]  LocalTypography -> LocalClodyTypography 수정으로 통일성 개선
- [x] LocalTypography 부분 줄바꿈 제거
- [x] CLODYTheme 함수 MaterialTheme 들여쓰기 제거
- [x] color -> colors 로 통일
- [x] LocalClodyColors 선언 람다식 수정

## ✨ PR 포인트
- naming 통일감을 좀 개선해봤습니다 ,, 다음부터는 최대한 한번에 잘 확인하고 머지하겠습니다!
