### PR TITLE
[HOTFIX/#90] 온보딩 알림설정 피커 오류 해결

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/timepicker/ClodyPicker.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/timepicker/ClodyPicker.kt
@@ -40,17 +40,15 @@ fun ClodyPicker(
     infiniteScroll: Boolean = true
 ) {
     val visibleItemsMiddle = visibleItemsCount / 2
-    val emptyItems = List(visibleItemsMiddle) { "" }
-    val paddedItems = emptyItems + items + emptyItems
-    val listScrollCount = if (infiniteScroll) Integer.MAX_VALUE else paddedItems.size
+    val listScrollCount = if (infiniteScroll) Integer.MAX_VALUE else items.size + visibleItemsMiddle * 2
     val listScrollMiddle = listScrollCount / 2
     val listStartIndex = if (infiniteScroll) {
-        listScrollMiddle - listScrollMiddle % paddedItems.size - visibleItemsMiddle + startIndex
+        listScrollMiddle - listScrollMiddle % items.size - visibleItemsMiddle + startIndex
     } else {
-        startIndex + visibleItemsMiddle
+        startIndex
     }
 
-    fun getItem(index: Int) = paddedItems.getOrNull(index).orEmpty()
+    fun getItem(index: Int) = items.getOrNull(index % items.size) ?: ""
 
     val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
@@ -99,26 +97,26 @@ fun ClodyPicker(
                 }
         ) {
             items(listScrollCount) { index ->
-                Text(
-                    text = getItem(index),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = ClodyTheme.typography.head3Medium.copy(color = ClodyTheme.colors.gray01),
-                    modifier = Modifier
-                        .onSizeChanged { size -> itemHeightPixels.intValue = size.height }
-                        .then(textModifier)
-                )
+                if (!infiniteScroll && (index < visibleItemsMiddle || index >= items.size + visibleItemsMiddle)) {
+                    Text(
+                        text = "",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = ClodyTheme.typography.head3Medium.copy(color = ClodyTheme.colors.gray01),
+                        modifier = Modifier.height(itemHeightDp)
+                    )
+                } else {
+                    Text(
+                        text = getItem(index),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = ClodyTheme.typography.head3Medium.copy(color = ClodyTheme.colors.gray01),
+                        modifier = Modifier
+                            .onSizeChanged { size -> itemHeightPixels.intValue = size.height }
+                            .then(textModifier)
+                    )
+                }
             }
         }
     }
-}
-
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewPicker() {
-    ClodyPicker(
-        items = (1..99).map { it.toString() },
-        visibleItemsCount = 5,
-    )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/timepicker/YearMonthPicker.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/timepicker/YearMonthPicker.kt
@@ -1,4 +1,4 @@
-package com.sopt.clody.presentation.ui.component
+package com.sopt.clody.presentation.ui.component.timepicker
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -26,8 +26,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.sopt.clody.R
 import com.sopt.clody.presentation.ui.component.button.ClodyButton
-import com.sopt.clody.presentation.ui.component.timepicker.ClodyPicker
-import com.sopt.clody.presentation.ui.component.timepicker.rememberPickerState
 import com.sopt.clody.ui.theme.ClodyTheme
 
 @Composable
@@ -104,7 +102,7 @@ fun YearMonthPicker(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Spacer(modifier = Modifier.weight(1f))
-                    ClodyPicker(
+                    YearMonthPickerItem(
                         state = yearPickerState,
                         items = yearItems,
                         startIndex = startYearIndex,
@@ -115,7 +113,7 @@ fun YearMonthPicker(
                         textModifier = Modifier.padding(8.dp),
                     )
                     Spacer(modifier = Modifier.width(20.dp))
-                    ClodyPicker(
+                    YearMonthPickerItem(
                         state = monthPickerState,
                         items = monthItems,
                         startIndex = startMonthIndex,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/timepicker/YearMonthPickerItem.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/timepicker/YearMonthPickerItem.kt
@@ -1,0 +1,124 @@
+package com.sopt.clody.presentation.ui.component.timepicker
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import com.sopt.clody.ui.theme.ClodyTheme
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun YearMonthPickerItem(
+    modifier: Modifier = Modifier,
+    items: List<String>,
+    state: PickerState = rememberPickerState(),
+    startIndex: Int = 0,
+    visibleItemsCount: Int,
+    textModifier: Modifier = Modifier,
+    infiniteScroll: Boolean = true
+) {
+    val visibleItemsMiddle = visibleItemsCount / 2
+    val emptyItems = List(visibleItemsMiddle) { "" }
+    val paddedItems = emptyItems + items + emptyItems
+    val listScrollCount = if (infiniteScroll) Integer.MAX_VALUE else paddedItems.size
+    val listScrollMiddle = listScrollCount / 2
+    val listStartIndex = if (infiniteScroll) {
+        listScrollMiddle - listScrollMiddle % paddedItems.size - visibleItemsMiddle + startIndex
+    } else {
+        startIndex + visibleItemsMiddle
+    }
+
+    fun getItem(index: Int) = paddedItems.getOrNull(index).orEmpty()
+
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    val itemHeightPixels = remember { mutableIntStateOf(0) }
+    val itemHeightDp = with(LocalDensity.current) { itemHeightPixels.intValue.toDp() }
+
+    val fadingEdgeGradient = remember {
+        Brush.verticalGradient(
+            0f to Color.White.copy(alpha = 0.9f),
+            0.1f to Color.White.copy(alpha = 0.8f),
+            0.2f to Color.White.copy(alpha = 0.7f),
+            0.3f to Color.White.copy(alpha = 0.6f),
+            0.4f to Color.Transparent,
+            0.5f to Color.Transparent,
+            0.6f to Color.Transparent,
+            0.7f to Color.White.copy(alpha = 0.7f),
+            0.8f to Color.White.copy(alpha = 0.8f),
+            0.9f to Color.White.copy(alpha = 0.9f),
+        )
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .map { index -> getItem(index + visibleItemsMiddle) }
+            .distinctUntilChanged()
+            .collect { item -> state.selectedItem = item }
+    }
+
+    Box(modifier = modifier) {
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(itemHeightDp * visibleItemsCount)
+                .pointerInput(Unit) {
+                    detectVerticalDragGestures { change, dragAmount ->
+                        change.consume()
+                    }
+                }
+                .drawWithContent {
+                    drawContent()
+                    drawRect(fadingEdgeGradient, size = size)
+                }
+        ) {
+            items(listScrollCount) { index ->
+                Text(
+                    text = getItem(index),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = ClodyTheme.typography.head3Medium.copy(color = ClodyTheme.colors.gray01),
+                    modifier = Modifier
+                        .onSizeChanged { size -> itemHeightPixels.intValue = size.height }
+                        .then(textModifier)
+                )
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewPicker() {
+    YearMonthPickerItem(
+        items = (1..99).map { it.toString() },
+        visibleItemsCount = 5,
+    )
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.sopt.clody.presentation.ui.component.YearMonthPicker
+import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.component.popup.ClodyPopupBottomSheet
 import com.sopt.clody.presentation.ui.diarylist.component.DiaryListTopAppBar
 import com.sopt.clody.presentation.ui.diarylist.component.MonthlyDiaryList

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
-import com.sopt.clody.presentation.ui.component.YearMonthPicker
+import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.component.bottomsheet.DiaryDeleteSheet
 import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
 import com.sopt.clody.presentation.ui.component.popup.ClodyPopupBottomSheet


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #90 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 온보딩에서 알림설정을 할때 사용하는 시간 피커 오류 해결
   -> 연,월 피커에서 앞 원소가 밑으로 밀리는 현상을 해결하기 위해 빈 아이템을 집어 넣어주는 방식을 사용했는데. 무한스크롤을 허용하는 시간 피커에서는 빈 아이템이 무한으로 반복되어 발생한 현상 같습니다.

- [x] 기존 잘 작동하던 ClodyPicker 컴포넌트 복원
- [x] 현재 사용하고 있는 ClodyPicker는 연,월 피커를 위한 YearMonthPickerItem로 새로 생성

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->


## 📸 스크린샷/동영상

https://github.com/user-attachments/assets/11cd1ed0-4b5f-4835-93cd-b12b87ba31c1

