### PR TITLE
[FEAT/#121] "캘린더뷰 > 리스트뷰" 연,월 값 반영

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/navigation/AuthNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/navigation/AuthNavigator.kt
@@ -1,6 +1,7 @@
 package com.sopt.clody.presentation.ui.auth.navigation
 
 import androidx.navigation.NavHostController
+import java.time.LocalDate
 
 
 class AuthNavigator(
@@ -21,7 +22,7 @@ class AuthNavigator(
         navController.navigate("time_reminder")
     }
 
-    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+    fun navigateHome(selectedYear: Int = LocalDate.now().year, selectedMonth: Int = LocalDate.now().monthValue) {
         navController.navigate("home/$selectedYear/$selectedMonth")
     }
 

--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/navigation/AuthNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/navigation/AuthNavigator.kt
@@ -21,12 +21,12 @@ class AuthNavigator(
         navController.navigate("time_reminder")
     }
 
-    fun navigateHome() {
-        navController.navigate("home")
+    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+        navController.navigate("home/$selectedYear/$selectedMonth")
     }
 
     fun navigateBack() {
-        navController.popBackStack()
+        navController.navigateUp()
     }
     fun navigateToSignupScreen() {
         navController.navigate("register") {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/screen/GuideScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/screen/GuideScreen.kt
@@ -35,14 +35,12 @@ import com.sopt.clody.presentation.ui.auth.navigation.AuthNavigator
 import com.sopt.clody.presentation.ui.component.button.ClodyButton
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.launch
-import java.time.LocalDate
 
 @Composable
 fun GuideRoute(
     navigator: AuthNavigator
 ) {
-    GuideScreen(onNextButtonClick = { navigator.navigateHome(LocalDate.now().year, LocalDate.now().monthValue) }
-    )
+    GuideScreen(onNextButtonClick = { navigator.navigateHome() })
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/screen/GuideScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/screen/GuideScreen.kt
@@ -35,12 +35,13 @@ import com.sopt.clody.presentation.ui.auth.navigation.AuthNavigator
 import com.sopt.clody.presentation.ui.component.button.ClodyButton
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 
 @Composable
 fun GuideRoute(
     navigator: AuthNavigator
 ) {
-    GuideScreen(onNextButtonClick = { navigator.navigateHome() }
+    GuideScreen(onNextButtonClick = { navigator.navigateHome(LocalDate.now().year, LocalDate.now().monthValue) }
     )
 }
 

--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/signup/SignUpScreen.kt
@@ -26,7 +26,6 @@ import com.sopt.clody.presentation.utils.base.UiState
 import com.sopt.clody.presentation.utils.extension.showLongToast
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.launch
-import java.time.LocalDate
 
 @Composable
 fun SignUpRoute(
@@ -40,8 +39,9 @@ fun SignUpRoute(
     LaunchedEffect(signInState) {
         when (val result = signInState.uiState) {
             is UiState.Success -> {
-                authNavigator.navigateHome(LocalDate.now().year, LocalDate.now().monthValue)
+                authNavigator.navigateHome()
             }
+
             is UiState.Failure -> {
                 if (result.msg.contains("404") || result.msg.contains("User not found")) {
                     authNavigator.navigateTermsOfService()
@@ -51,6 +51,7 @@ fun SignUpRoute(
                     }
                 }
             }
+
             else -> {}
         }
     }
@@ -60,6 +61,7 @@ fun SignUpRoute(
         onSignInClick = { viewModel.signInWithKakao(context) },
     )
 }
+
 @Composable
 fun SignUpScreen(
     signInState: SignInState,
@@ -132,6 +134,7 @@ fun SignUpScreen(
         }
     }
 }
+
 @Preview(showBackground = true)
 @Composable
 fun RegisterScreenPreview() {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/signup/SignUpScreen.kt
@@ -26,6 +26,7 @@ import com.sopt.clody.presentation.utils.base.UiState
 import com.sopt.clody.presentation.utils.extension.showLongToast
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 
 @Composable
 fun SignUpRoute(
@@ -39,7 +40,7 @@ fun SignUpRoute(
     LaunchedEffect(signInState) {
         when (val result = signInState.uiState) {
             is UiState.Success -> {
-                authNavigator.navigateHome()
+                authNavigator.navigateHome(LocalDate.now().year, LocalDate.now().monthValue)
             }
             is UiState.Failure -> {
                 if (result.msg.contains("404") || result.msg.contains("User not found")) {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
@@ -7,13 +7,26 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
 import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
+import java.time.LocalDate
 
 fun NavGraphBuilder.diaryListNavGraph(
     navigator: DiaryListNavigator,
     replyLoadingNavigator: ReplyLoadingNavigator
 ) {
-    composable("diary_list") {
-        DiaryListRoute(navigator)
+    composable(
+        route = "diary_list/{selectedYearFromHome}/{selectedMonthFromHome}",
+        arguments = listOf(
+            navArgument("selectedYearFromHome") { type = NavType.IntType },
+            navArgument("selectedMonthFromHome") { type = NavType.IntType }
+        )
+    ) { backStackEntry ->
+        val selectedYearFromHome = backStackEntry.arguments?.getInt("selectedYearFromHome") ?: LocalDate.now().year
+        val selectedMonthFromHome = backStackEntry.arguments?.getInt("selectedMonthFromHome") ?: LocalDate.now().monthValue
+        DiaryListRoute(
+            navigator = diaryListNavigator,
+            selectedYearFromHome = selectedYearFromHome,
+            selectedMonthFromHome = selectedMonthFromHome
+        )
     }
     composable("reply_loading/{year}/{month}/{day}?from={from}",
         arguments = listOf(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
@@ -5,13 +5,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
-import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
 import java.time.LocalDate
 
 fun NavGraphBuilder.diaryListNavGraph(
     diaryListNavigator: DiaryListNavigator,
-    replyLoadingNavigator: ReplyLoadingNavigator
 ) {
     composable(
         route = "diary_list/{selectedYearFromHome}/{selectedMonthFromHome}",
@@ -20,34 +17,13 @@ fun NavGraphBuilder.diaryListNavGraph(
             navArgument("selectedMonthFromHome") { type = NavType.IntType }
         )
     ) { backStackEntry ->
-        val selectedYearFromHome = backStackEntry.arguments?.getInt("selectedYearFromHome") ?: LocalDate.now().year
-        val selectedMonthFromHome = backStackEntry.arguments?.getInt("selectedMonthFromHome") ?: LocalDate.now().monthValue
+        val currentDate = LocalDate.now()
+        val selectedYearFromHome = backStackEntry.arguments?.getInt("selectedYearFromHome") ?: currentDate.year
+        val selectedMonthFromHome = backStackEntry.arguments?.getInt("selectedMonthFromHome") ?: currentDate.monthValue
         DiaryListRoute(
             navigator = diaryListNavigator,
             selectedYearFromHome = selectedYearFromHome,
             selectedMonthFromHome = selectedMonthFromHome
-        )
-    }
-
-    composable(
-        route = "reply_loading/{year}/{month}/{day}?from={from}",
-        arguments = listOf(
-            navArgument("year") { type = NavType.IntType },
-            navArgument("month") { type = NavType.IntType },
-            navArgument("day") { type = NavType.IntType },
-            navArgument("from") { defaultValue = "diary_list" } // 기본값 설정
-        )
-    ) { backStackEntry ->
-        val year = backStackEntry.arguments?.getInt("year") ?: 0
-        val month = backStackEntry.arguments?.getInt("month") ?: 0
-        val day = backStackEntry.arguments?.getInt("day") ?: 0
-        val from = backStackEntry.arguments?.getString("from") ?: "diary_list" // from 파라미터 가져오기
-        ReplyLoadingRoute(
-            navigator = replyLoadingNavigator,
-            year = year,
-            month = month,
-            day = day,
-            from = from
         )
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
@@ -10,7 +10,7 @@ import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
 import java.time.LocalDate
 
 fun NavGraphBuilder.diaryListNavGraph(
-    navigator: DiaryListNavigator,
+    diaryListNavigator: DiaryListNavigator,
     replyLoadingNavigator: ReplyLoadingNavigator
 ) {
     composable(
@@ -28,7 +28,9 @@ fun NavGraphBuilder.diaryListNavGraph(
             selectedMonthFromHome = selectedMonthFromHome
         )
     }
-    composable("reply_loading/{year}/{month}/{day}?from={from}",
+
+    composable(
+        route = "reply_loading/{year}/{month}/{day}?from={from}",
         arguments = listOf(
             navArgument("year") { type = NavType.IntType },
             navArgument("month") { type = NavType.IntType },
@@ -40,6 +42,12 @@ fun NavGraphBuilder.diaryListNavGraph(
         val month = backStackEntry.arguments?.getInt("month") ?: 0
         val day = backStackEntry.arguments?.getInt("day") ?: 0
         val from = backStackEntry.arguments?.getString("from") ?: "diary_list" // from 파라미터 가져오기
-        ReplyLoadingRoute(replyLoadingNavigator, year, month, day, from)
+        ReplyLoadingRoute(
+            navigator = replyLoadingNavigator,
+            year = year,
+            month = month,
+            day = day,
+            from = from
+        )
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavigator.kt
@@ -14,6 +14,6 @@ class DiaryListNavigator(
     }
 
     fun navigateBack() {
-        navController.popBackStack()
+        navController.navigateUp()
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavigator.kt
@@ -5,8 +5,8 @@ import androidx.navigation.NavController
 class DiaryListNavigator(
     val navController: NavController
 ) {
-    fun navigateCalendar() {
-        navController.navigate("home")
+    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+        navController.navigate("home/$selectedYear/$selectedMonth")
     }
 
     fun navigateReplyLoading(year: Int, month: Int, day: Int) {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -35,11 +35,15 @@ import java.time.LocalDate
 @Composable
 fun DiaryListRoute(
     navigator: DiaryListNavigator,
-    diaryListViewModel: DiaryListViewModel = hiltViewModel()
+    diaryListViewModel: DiaryListViewModel = hiltViewModel(),
+    selectedYearFromHome: Int,
+    selectedMonthFromHome: Int
 ) {
     DiaryListScreen(
         diaryListViewModel = diaryListViewModel,
         onClickCalendar = { navigator.navigateCalendar() },
+        selectedYearFromHome = selectedYearFromHome,
+        selectedMonthFromHome = selectedMonthFromHome,
         onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) }
     )
 }
@@ -48,22 +52,26 @@ fun DiaryListRoute(
 fun DiaryListScreen(
     diaryListViewModel: DiaryListViewModel,
     onClickCalendar: () -> Unit,
+    selectedYearFromHome: Int,
+    selectedMonthFromHome: Int,
     onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
     var showYearMonthPickerState by remember { mutableStateOf(false) }
     val currentDate = LocalDate.now()
     var selectedYear by remember { mutableIntStateOf(currentDate.year) }
     var selectedMonth by remember { mutableIntStateOf(currentDate.monthValue) }
+    var selectedYearInDiaryList by remember { mutableIntStateOf(selectedYearFromHome) }
+    var selectedMonthInDiaryList by remember { mutableIntStateOf(selectedMonthFromHome) }
     val diaryListState by diaryListViewModel.diaryListState.collectAsState()
     val deleteDiaryResult by diaryListViewModel.deleteDiaryResult.collectAsState()
 
     val onYearMonthSelected: (Int, Int) -> Unit = { year, month ->
-        selectedYear = year
-        selectedMonth = month
+        selectedYearInDiaryList = year
+        selectedMonthInDiaryList = month
     }
 
-    LaunchedEffect(selectedYear, selectedMonth) {
-        diaryListViewModel.fetchMonthlyDiary(selectedYear, selectedMonth)
+    LaunchedEffect(selectedYearInDiaryList, selectedMonthInDiaryList) {
+        diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
     }
 
     when (deleteDiaryResult) {
@@ -72,7 +80,7 @@ fun DiaryListScreen(
 
         is DeleteDiaryListState.Success -> {
             LaunchedEffect(Unit) {
-                diaryListViewModel.fetchMonthlyDiary(selectedYear, selectedMonth)
+                diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
             }
         }
 
@@ -86,9 +94,9 @@ fun DiaryListScreen(
         topBar = {
             Column {
                 DiaryListTopAppBar(
-                    onClickCalendar = onClickCalendar,
-                    selectedYear = selectedYear,
-                    selectedMonth = selectedMonth,
+                    onClickCalendar = { onClickCalendar(selectedYearInDiaryList, selectedMonthInDiaryList) },
+                    selectedYear = selectedYearInDiaryList,
+                    selectedMonth = selectedMonthInDiaryList,
                     onShowYearMonthPickerStateChange = { newState -> showYearMonthPickerState = newState }
                 )
                 Box(
@@ -134,8 +142,8 @@ fun DiaryListScreen(
             ClodyPopupBottomSheet(onDismissRequest = { showYearMonthPickerState = false }) {
                 YearMonthPicker(
                     onDismissRequest = { showYearMonthPickerState = false },
-                    selectedYear = selectedYear,
-                    selectedMonth = selectedMonth,
+                    selectedYear = selectedYearInDiaryList,
+                    selectedMonth = selectedMonthInDiaryList,
                     onYearMonthSelected = onYearMonthSelected
                 )
             }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.component.popup.ClodyPopupBottomSheet
+import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.diarylist.component.DiaryListTopAppBar
 import com.sopt.clody.presentation.ui.diarylist.component.MonthlyDiaryList
 import com.sopt.clody.presentation.ui.diarylist.navigation.DiaryListNavigator
@@ -30,7 +30,6 @@ import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListState
 import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListViewModel
 import com.sopt.clody.presentation.utils.extension.showToast
 import com.sopt.clody.ui.theme.ClodyTheme
-import java.time.LocalDate
 
 @Composable
 fun DiaryListRoute(
@@ -41,9 +40,9 @@ fun DiaryListRoute(
 ) {
     DiaryListScreen(
         diaryListViewModel = diaryListViewModel,
-        onClickCalendar = { navigator.navigateCalendar() },
         selectedYearFromHome = selectedYearFromHome,
         selectedMonthFromHome = selectedMonthFromHome,
+        onClickCalendar = { selectedYearFromDiaryList, selectedMonthFromDiaryList -> navigator.navigateHome(selectedYearFromDiaryList, selectedMonthFromDiaryList) },
         onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) }
     )
 }
@@ -51,15 +50,12 @@ fun DiaryListRoute(
 @Composable
 fun DiaryListScreen(
     diaryListViewModel: DiaryListViewModel,
-    onClickCalendar: () -> Unit,
     selectedYearFromHome: Int,
     selectedMonthFromHome: Int,
+    onClickCalendar: (Int, Int) -> Unit,
     onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
     var showYearMonthPickerState by remember { mutableStateOf(false) }
-    val currentDate = LocalDate.now()
-    var selectedYear by remember { mutableIntStateOf(currentDate.year) }
-    var selectedMonth by remember { mutableIntStateOf(currentDate.monthValue) }
     var selectedYearInDiaryList by remember { mutableIntStateOf(selectedYearFromHome) }
     var selectedMonthInDiaryList by remember { mutableIntStateOf(selectedMonthFromHome) }
     val diaryListState by diaryListViewModel.diaryListState.collectAsState()

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavGraph.kt
@@ -7,13 +7,26 @@ import androidx.navigation.navArgument
 import com.sopt.clody.presentation.ui.home.screen.HomeRoute
 import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
 import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
+import java.time.LocalDate
 
 fun NavGraphBuilder.homeNavGraph(
     navigator: HomeNavigator,
     replyLoadingNavigator: ReplyLoadingNavigator
 ) {
-    composable("home") {
-        HomeRoute(navigator)
+    composable(
+        route = "home/{selectedYear}/{selectedMonth}",
+        arguments = listOf(
+            navArgument("selectedYear") { type = NavType.IntType },
+            navArgument("selectedMonth") { type = NavType.IntType }
+        )
+    ) { backStackEntry ->
+        val selectedYear = backStackEntry.arguments?.getInt("selectedYear") ?: LocalDate.now().year
+        val selectedMonth = backStackEntry.arguments?.getInt("selectedMonth") ?: LocalDate.now().monthValue
+        HomeRoute(
+            navigator = navigator,
+            selectedYear = selectedYear,
+            selectedMonth = selectedMonth
+        )
     }
     composable("reply_loading/{year}/{month}/{day}?from={from}",
         arguments = listOf(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavGraph.kt
@@ -5,13 +5,10 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.sopt.clody.presentation.ui.home.screen.HomeRoute
-import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
-import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
 import java.time.LocalDate
 
 fun NavGraphBuilder.homeNavGraph(
     navigator: HomeNavigator,
-    replyLoadingNavigator: ReplyLoadingNavigator
 ) {
     composable(
         route = "home/{selectedYear}/{selectedMonth}",
@@ -20,34 +17,13 @@ fun NavGraphBuilder.homeNavGraph(
             navArgument("selectedMonth") { type = NavType.IntType }
         )
     ) { backStackEntry ->
-        val selectedYear = backStackEntry.arguments?.getInt("selectedYear") ?: LocalDate.now().year
-        val selectedMonth = backStackEntry.arguments?.getInt("selectedMonth") ?: LocalDate.now().monthValue
+        val currentDate = LocalDate.now()
+        val selectedYear = backStackEntry.arguments?.getInt("selectedYear") ?: currentDate.year
+        val selectedMonth = backStackEntry.arguments?.getInt("selectedMonth") ?: currentDate.monthValue
         HomeRoute(
             navigator = navigator,
             selectedYear = selectedYear,
             selectedMonth = selectedMonth
-        )
-    }
-
-    composable(
-        route = "reply_loading/{year}/{month}/{day}?from={from}",
-        arguments = listOf(
-            navArgument("year") { type = NavType.IntType },
-            navArgument("month") { type = NavType.IntType },
-            navArgument("day") { type = NavType.IntType },
-            navArgument("from") { defaultValue = "home" } // 기본값 설정
-        )
-    ) { backStackEntry ->
-        val year = backStackEntry.arguments?.getInt("year") ?: 0
-        val month = backStackEntry.arguments?.getInt("month") ?: 0
-        val day = backStackEntry.arguments?.getInt("day") ?: 0
-        val from = backStackEntry.arguments?.getString("from") ?: "home"
-        ReplyLoadingRoute(
-            navigator = replyLoadingNavigator,
-            year = year,
-            month = month,
-            day = day,
-            from = from
         )
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavGraph.kt
@@ -28,7 +28,9 @@ fun NavGraphBuilder.homeNavGraph(
             selectedMonth = selectedMonth
         )
     }
-    composable("reply_loading/{year}/{month}/{day}?from={from}",
+
+    composable(
+        route = "reply_loading/{year}/{month}/{day}?from={from}",
         arguments = listOf(
             navArgument("year") { type = NavType.IntType },
             navArgument("month") { type = NavType.IntType },
@@ -40,6 +42,12 @@ fun NavGraphBuilder.homeNavGraph(
         val month = backStackEntry.arguments?.getInt("month") ?: 0
         val day = backStackEntry.arguments?.getInt("day") ?: 0
         val from = backStackEntry.arguments?.getString("from") ?: "home"
-        ReplyLoadingRoute(replyLoadingNavigator, year, month, day, from)
+        ReplyLoadingRoute(
+            navigator = replyLoadingNavigator,
+            year = year,
+            month = month,
+            day = day,
+            from = from
+        )
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavigator.kt
@@ -22,7 +22,7 @@ class HomeNavigator(
     }
 
     fun navigateBack() {
-        navController.popBackStack()
+        navController.navigateUp()
     }
 }
 

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavigator.kt
@@ -5,8 +5,8 @@ import androidx.navigation.NavController
 class HomeNavigator(
     val navController: NavController
 ) {
-    fun navigateDiaryList() {
-        navController.navigate("diary_list")
+    fun navigateDiaryList(selectedYear: Int, selectedMonth: Int) {
+        navController.navigate("diary_list/$selectedYear/$selectedMonth")
     }
 
     fun navigateSetting() {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -43,7 +43,7 @@ fun HomeRoute(
 ) {
     HomeScreen(
         homeViewModel = homeViewModel,
-        onClickDiaryList = { navigator.navigateDiaryList() },
+        onClickDiaryList = { selectedYearFromHome, selectedMonthFromHome -> navigator.navigateDiaryList(selectedYearFromHome, selectedMonthFromHome) },
         onClickSetting = { navigator.navigateSetting() },
         onClickWriteDiary = { year, month, day -> navigator.navigateWriteDiary(year, month, day) },
         onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) }
@@ -53,7 +53,7 @@ fun HomeRoute(
 @Composable
 fun HomeScreen(
     homeViewModel: HomeViewModel,
-    onClickDiaryList: () -> Unit,
+    onClickDiaryList: (Int, Int) -> Unit,
     onClickSetting: () -> Unit,
     onClickWriteDiary: (Int, Int, Int) -> Unit,
     onClickReplyDiary: (Int, Int, Int) -> Unit,
@@ -104,7 +104,7 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             HomeTopAppBar(
-                onClickDiaryList = onClickDiaryList,
+                onClickDiaryList = { onClickDiaryList(selectedYearInCalendar,selectedMonthInCalendar) },
                 onClickSetting = onClickSetting,
                 onShowYearMonthPickerStateChange = { newState -> showYearMonthPickerState = newState },
                 selectedYear = selectedYear,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -39,14 +40,18 @@ import java.time.LocalDate
 @Composable
 fun HomeRoute(
     navigator: HomeNavigator,
-    homeViewModel: HomeViewModel = hiltViewModel()
+    homeViewModel: HomeViewModel = hiltViewModel(),
+    selectedYear: Int,
+    selectedMonth: Int,
 ) {
     HomeScreen(
         homeViewModel = homeViewModel,
         onClickDiaryList = { selectedYearFromHome, selectedMonthFromHome -> navigator.navigateDiaryList(selectedYearFromHome, selectedMonthFromHome) },
         onClickSetting = { navigator.navigateSetting() },
         onClickWriteDiary = { year, month, day -> navigator.navigateWriteDiary(year, month, day) },
-        onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) }
+        onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) },
+        selectedYear = selectedYear,
+        selectedMonth = selectedMonth
     )
 }
 
@@ -57,13 +62,15 @@ fun HomeScreen(
     onClickSetting: () -> Unit,
     onClickWriteDiary: (Int, Int, Int) -> Unit,
     onClickReplyDiary: (Int, Int, Int) -> Unit,
+    selectedYear: Int,
+    selectedMonth: Int
 ) {
     var showYearMonthPickerState by remember { mutableStateOf(false) }
     var showDiaryDeleteState by remember { mutableStateOf(false) }
     var showDiaryDeleteDialog by remember { mutableStateOf(false) }
     val currentDate = LocalDate.now()
-    var selectedYear by remember { mutableStateOf(currentDate.year) }
-    var selectedMonth by remember { mutableStateOf(currentDate.monthValue) }
+    var selectedYearInCalendar by remember { mutableIntStateOf(selectedYear) }
+    var selectedMonthInCalendar by remember { mutableIntStateOf(selectedMonth) }
 
     val selectedDate by homeViewModel.selectedDate.collectAsStateWithLifecycle()
     val diaryCount by homeViewModel.diaryCount.collectAsStateWithLifecycle()
@@ -72,16 +79,16 @@ fun HomeScreen(
     val deleteDiaryResult by homeViewModel.deleteDiaryResult.collectAsStateWithLifecycle()
     val calendarData by homeViewModel.monthlyCalendarData.collectAsStateWithLifecycle()
 
-    LaunchedEffect(selectedYear, selectedMonth) {
-        homeViewModel.loadCalendarData(selectedYear, selectedMonth)
-        if (selectedYear == currentDate.year && selectedMonth == currentDate.monthValue) {
+    LaunchedEffect(selectedYearInCalendar, selectedMonthInCalendar) {
+        homeViewModel.loadCalendarData(selectedYearInCalendar, selectedMonthInCalendar)
+        if (selectedYearInCalendar == currentDate.year && selectedMonthInCalendar == currentDate.monthValue) {
             homeViewModel.updateSelectedDate(currentDate)
         }
     }
 
     LaunchedEffect(deleteDiaryResult) {
         if (deleteDiaryResult is DeleteDiaryState.Success) {
-            homeViewModel.loadCalendarData(selectedYear, selectedMonth)
+            homeViewModel.loadCalendarData(selectedYearInCalendar, selectedMonthInCalendar)
             homeViewModel.loadDailyDiariesData(selectedDate.year, selectedDate.monthValue, selectedDate.dayOfMonth)
         }
     }
@@ -107,8 +114,8 @@ fun HomeScreen(
                 onClickDiaryList = { onClickDiaryList(selectedYearInCalendar,selectedMonthInCalendar) },
                 onClickSetting = onClickSetting,
                 onShowYearMonthPickerStateChange = { newState -> showYearMonthPickerState = newState },
-                selectedYear = selectedYear,
-                selectedMonth = selectedMonth,
+                selectedYear = selectedYearInCalendar,
+                selectedMonth = selectedMonthInCalendar,
             )
         },
         content = { innerPadding ->
@@ -116,8 +123,8 @@ fun HomeScreen(
                 result.fold(
                     onSuccess = { data ->
                         ScrollableCalendarView(
-                            selectedYear = selectedYear,
-                            selectedMonth = selectedMonth,
+                            selectedYear = selectedYearInCalendar,
+                            selectedMonth = selectedMonthInCalendar,
                             cloverCount = data.totalCloverCount,
                             diaries = data.diaries,
                             homeViewModel = homeViewModel,
@@ -156,11 +163,11 @@ fun HomeScreen(
         ClodyPopupBottomSheet(onDismissRequest = { showYearMonthPickerState = false }) {
             YearMonthPicker(
                 onDismissRequest = { showYearMonthPickerState = false },
-                selectedYear = selectedYear,
-                selectedMonth = selectedMonth,
+                selectedYear = selectedYearInCalendar,
+                selectedMonth = selectedMonthInCalendar,
                 onYearMonthSelected = { year, month ->
-                    selectedYear = year
-                    selectedMonth = month
+                    selectedYearInCalendar = year
+                    selectedMonthInCalendar = month
                     val newDate = if (year == currentDate.year && month == currentDate.monthValue) {
                         currentDate
                     } else {
@@ -187,7 +194,7 @@ fun HomeScreen(
             confirmOption = "삭제할래요",
             dismissOption = "아니요",
             confirmAction = {
-                homeViewModel.deleteDailyDiary(selectedYear, selectedMonth, selectedDate.dayOfMonth)
+                homeViewModel.deleteDailyDiary(selectedYearInCalendar, selectedMonthInCalendar, selectedDate.dayOfMonth)
                 showDiaryDeleteDialog = false
             },
             onDismiss = { showDiaryDeleteDialog = false },

--- a/app/src/main/java/com/sopt/clody/presentation/ui/navigatior/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/navigatior/MainNavHost.kt
@@ -6,24 +6,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.navigation
 import com.sopt.clody.presentation.ui.auth.navigation.AuthNavigator
 import com.sopt.clody.presentation.ui.auth.navigation.guidNavGraph
 import com.sopt.clody.presentation.ui.auth.navigation.nicknameNavGraph
 import com.sopt.clody.presentation.ui.auth.navigation.registerNavGraph
 import com.sopt.clody.presentation.ui.auth.navigation.termsOfServiceNavGraph
 import com.sopt.clody.presentation.ui.auth.navigation.timeReminderNavGraph
-import com.sopt.clody.presentation.ui.auth.screen.NicknameScreen
 import com.sopt.clody.presentation.ui.diarylist.navigation.DiaryListNavigator
 import com.sopt.clody.presentation.ui.diarylist.navigation.diaryListNavGraph
 import com.sopt.clody.presentation.ui.home.navigation.HomeNavigator
 import com.sopt.clody.presentation.ui.home.navigation.homeNavGraph
-import com.sopt.clody.presentation.ui.home.screen.HomeRoute
-import com.sopt.clody.presentation.ui.home.screen.HomeScreen
 import com.sopt.clody.presentation.ui.replydiary.navigation.ReplyDiaryNavigator
 import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
 import com.sopt.clody.presentation.ui.replyloading.navigation.replyLoadingNavGraph
@@ -62,9 +57,9 @@ fun MainNavHost(
             nicknameNavGraph(authNavigator)
             guidNavGraph(authNavigator)
             timeReminderNavGraph(authNavigator)
-            homeNavGraph(homeNavigator, replyLoadingNavigator)
-            diaryListNavGraph(diaryListNavigator, replyLoadingNavigator)
-            writeDiaryNavGraph(writeDiaryNavigator, replyLoadingNavigator)
+            homeNavGraph(homeNavigator)
+            diaryListNavGraph(diaryListNavigator)
+            writeDiaryNavGraph(writeDiaryNavigator)
             settingNavGraph(settingNavigator)
             accountManagementNavGraph(settingNavigator)
             notificationSettingNavGraph(settingNavigator)

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/ReplyDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/ReplyDiaryScreen.kt
@@ -58,7 +58,7 @@ fun ReplyDiaryRoute(
     BackHandler {
         val currentTime = System.currentTimeMillis()
         if (currentTime - backPressedTime <= backPressThreshold) {
-            navigator.navigateHome()
+            navigator.navigateHome(year, month)
         } else {
             backPressedTime = currentTime
         }
@@ -66,7 +66,7 @@ fun ReplyDiaryRoute(
 
     ReplyDiaryScreen(
         viewModel = viewModel,
-        onClickBack = { navigator.navigateHome() }
+        onClickBack = { navigator.navigateHome(year, month) }
     )
 }
 
@@ -149,6 +149,7 @@ fun ReplyDiaryScreen(
                             is ReplyDiaryState.Loading -> {
                                 CircularProgressIndicator()
                             }
+
                             is ReplyDiaryState.Success -> {
                                 val content = (replyDiaryState as ReplyDiaryState.Success).content
                                 val nickname = (replyDiaryState as ReplyDiaryState.Success).nickname
@@ -194,10 +195,12 @@ fun ReplyDiaryScreen(
                                     }
                                 }
                             }
+
                             is ReplyDiaryState.Failure -> {
                                 val error = (replyDiaryState as ReplyDiaryState.Failure).error
                                 Text("Error: $error")
                             }
+
                             is ReplyDiaryState.NotFound -> {
                                 Column(
                                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -220,6 +223,7 @@ fun ReplyDiaryScreen(
                                     )
                                 }
                             }
+
                             else -> {}
                         }
                     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/ReplyDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/ReplyDiaryScreen.kt
@@ -58,7 +58,7 @@ fun ReplyDiaryRoute(
     BackHandler {
         val currentTime = System.currentTimeMillis()
         if (currentTime - backPressedTime <= backPressThreshold) {
-            navigator.navigateHome(year, month)
+            navigator.navigateHome()
         } else {
             backPressedTime = currentTime
         }
@@ -66,7 +66,7 @@ fun ReplyDiaryRoute(
 
     ReplyDiaryScreen(
         viewModel = viewModel,
-        onClickBack = { navigator.navigateHome(year, month) }
+        onClickBack = { navigator.navigateHome() }
     )
 }
 

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/navigation/ReplyNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/navigation/ReplyNavigator.kt
@@ -1,11 +1,12 @@
 package com.sopt.clody.presentation.ui.replydiary.navigation
 
 import androidx.navigation.NavHostController
+import java.time.LocalDate
 
 class ReplyDiaryNavigator(
     val navController: NavHostController
 ) {
-    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+    fun navigateHome(selectedYear: Int = LocalDate.now().year, selectedMonth: Int = LocalDate.now().monthValue) {
         navController.navigate("home/$selectedYear/$selectedMonth") {
             popUpTo(navController.graph.startDestinationId) {
                 inclusive = true

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/navigation/ReplyNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/navigation/ReplyNavigator.kt
@@ -5,8 +5,8 @@ import androidx.navigation.NavHostController
 class ReplyDiaryNavigator(
     val navController: NavHostController
 ) {
-    fun navigateHome() {
-        navController.navigate("home") {
+    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+        navController.navigate("home/$selectedYear/$selectedMonth") {
             popUpTo(navController.graph.startDestinationId) {
                 inclusive = true
             }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/navigation/ReplyNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replydiary/navigation/ReplyNavigator.kt
@@ -14,6 +14,6 @@ class ReplyDiaryNavigator(
     }
 
     fun navigateBack() {
-        navController.popBackStack()
+        navController.navigateUp()
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/navigation/ReplyLoadingNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/navigation/ReplyLoadingNavGraph.kt
@@ -7,24 +7,26 @@ import androidx.navigation.navArgument
 import com.sopt.clody.presentation.ui.replydiary.ReplyDiaryRoute
 import com.sopt.clody.presentation.ui.replydiary.navigation.ReplyDiaryNavigator
 import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
+import java.time.LocalDate
 
 fun NavGraphBuilder.replyLoadingNavGraph(
     replyLoadingNavigator: ReplyLoadingNavigator,
     replyDiaryNavigator: ReplyDiaryNavigator
 ) {
+    val currentDate = LocalDate.now()
     composable(
         "reply_loading/{year}/{month}/{day}?from={from}",
         arguments = listOf(
             navArgument("year") { type = NavType.IntType },
             navArgument("month") { type = NavType.IntType },
             navArgument("day") { type = NavType.IntType },
-            navArgument("from") { defaultValue = "home" } // 기본값 설정
+            navArgument("from") { defaultValue = "home" }
         )
     ) { backStackEntry ->
-        val year = backStackEntry.arguments?.getInt("year") ?: 0
-        val month = backStackEntry.arguments?.getInt("month") ?: 0
-        val day = backStackEntry.arguments?.getInt("day") ?: 0
-        val from = backStackEntry.arguments?.getString("from") ?: "home" // from 파라미터 가져오기
+        val year = backStackEntry.arguments?.getInt("year") ?: currentDate.year
+        val month = backStackEntry.arguments?.getInt("month") ?: currentDate.monthValue
+        val day = backStackEntry.arguments?.getInt("day") ?: currentDate.dayOfMonth
+        val from = backStackEntry.arguments?.getString("from") ?: "home"
         ReplyLoadingRoute(replyLoadingNavigator, year, month, day, from)
     }
     composable(
@@ -35,9 +37,9 @@ fun NavGraphBuilder.replyLoadingNavGraph(
             navArgument("day") { type = NavType.IntType }
         )
     ) { backStackEntry ->
-        val year = backStackEntry.arguments?.getInt("year") ?: 0
-        val month = backStackEntry.arguments?.getInt("month") ?: 0
-        val day = backStackEntry.arguments?.getInt("day") ?: 0
+        val year = backStackEntry.arguments?.getInt("year") ?: currentDate.year
+        val month = backStackEntry.arguments?.getInt("month") ?: currentDate.monthValue
+        val day = backStackEntry.arguments?.getInt("day") ?: currentDate.monthValue
         ReplyDiaryRoute(replyDiaryNavigator, year, month, day)
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/navigation/ReplyLoadingNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/navigation/ReplyLoadingNavigator.kt
@@ -5,8 +5,8 @@ import androidx.navigation.NavHostController
 class ReplyLoadingNavigator(
     private val navController: NavHostController
 ) {
-    fun navigateHome() {
-        navController.navigate("home") {
+    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+        navController.navigate("home/$selectedYear/$selectedMonth") {
             popUpTo(navController.graph.startDestinationId) {
                 inclusive = true
             }
@@ -17,22 +17,22 @@ class ReplyLoadingNavigator(
         navController.navigate("reply_diary/$year/$month/$day")
     }
 
-    fun navigateBack(from: String) {
+    fun navigateBack(selectedYear: Int, selectedMonth: Int, from: String) {
         when (from) {
             "diary_list" -> {
                 navController.popBackStack("diary_list", false)
             }
 
-            "home" -> {
-                navController.popBackStack("home", false)
+            "home/$selectedYear/$selectedMonth" -> {
+                navController.popBackStack("home/$selectedYear/$selectedMonth", false)
             }
 
             "write_diary" -> {
-                navController.popBackStack("home", false) // 예외적으로 홈으로 이동
+                navController.popBackStack("home/$selectedYear/$selectedMonth", false) // 예외적으로 홈으로 이동
             }
 
             else -> {
-                navController.popBackStack()
+                navController.navigateUp()
             }
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/navigation/ReplyLoadingNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/navigation/ReplyLoadingNavigator.kt
@@ -1,11 +1,12 @@
 package com.sopt.clody.presentation.ui.replyloading.navigation
 
 import androidx.navigation.NavHostController
+import java.time.LocalDate
 
 class ReplyLoadingNavigator(
     private val navController: NavHostController
 ) {
-    fun navigateHome(selectedYear: Int, selectedMonth: Int) {
+    fun navigateHome(selectedYear: Int = LocalDate.now().year, selectedMonth: Int = LocalDate.now().monthValue) {
         navController.navigate("home/$selectedYear/$selectedMonth") {
             popUpTo(navController.graph.startDestinationId) {
                 inclusive = true

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingScreen.kt
@@ -61,7 +61,7 @@ fun ReplyLoadingRoute(
     BackHandler {
         val currentTime = System.currentTimeMillis()
         if (currentTime - backPressedTime <= backPressThreshold) {
-            navigator.navigateHome(year, month)
+            navigator.navigateHome()
         } else {
             backPressedTime = currentTime
         }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingScreen.kt
@@ -61,7 +61,7 @@ fun ReplyLoadingRoute(
     BackHandler {
         val currentTime = System.currentTimeMillis()
         if (currentTime - backPressedTime <= backPressThreshold) {
-            navigator.navigateHome()
+            navigator.navigateHome(year, month)
         } else {
             backPressedTime = currentTime
         }
@@ -69,7 +69,7 @@ fun ReplyLoadingRoute(
 
     ReplyLoadingScreen(
         onCompleteClick = { navigator.navigateReplyDiary(year, month, day) },
-        onBackClick = { navigator.navigateBack(from) },
+        onBackClick = { navigator.navigateBack(year, month, from) },
         replyLoadingState = replyLoadingState
     )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavigator.kt
@@ -14,6 +14,6 @@ class SettingNavigator(
     }
 
     fun navigateBack() {
-        navController.popBackStack()
+        navController.navigateUp()
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/navigation/WriteDiaryNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/navigation/WriteDiaryNavGraph.kt
@@ -4,14 +4,12 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
-import com.sopt.clody.presentation.ui.replyloading.screen.ReplyLoadingRoute
 import com.sopt.clody.presentation.ui.writediary.screen.WriteDiaryRoute
+import java.time.LocalDate
 
 
 fun NavGraphBuilder.writeDiaryNavGraph(
     writeDiaryNavigator: WriteDiaryNavigator,
-    replyLoadingNavigator: ReplyLoadingNavigator
 ) {
     composable(
         "write_diary/{year}/{month}/{day}",
@@ -21,24 +19,10 @@ fun NavGraphBuilder.writeDiaryNavGraph(
             navArgument("day") { type = NavType.IntType }
         )
     ) { backStackEntry ->
-        val year = backStackEntry.arguments?.getInt("year") ?: 0
-        val month = backStackEntry.arguments?.getInt("month") ?: 0
-        val day = backStackEntry.arguments?.getInt("day") ?: 0
+        val currentDate = LocalDate.now()
+        val year = backStackEntry.arguments?.getInt("year") ?: currentDate.year
+        val month = backStackEntry.arguments?.getInt("month") ?: currentDate.monthValue
+        val day = backStackEntry.arguments?.getInt("day") ?: currentDate.dayOfMonth
         WriteDiaryRoute(writeDiaryNavigator, year, month, day)
-    }
-    composable(
-        "reply_loading/{year}/{month}/{day}?from={from}",
-        arguments = listOf(
-            navArgument("year") { type = NavType.IntType },
-            navArgument("month") { type = NavType.IntType },
-            navArgument("day") { type = NavType.IntType },
-            navArgument("from") { defaultValue = "write_diary" } // 기본값 설정
-        )
-    ) { backStackEntry ->
-        val year = backStackEntry.arguments?.getInt("year") ?: 0
-        val month = backStackEntry.arguments?.getInt("month") ?: 0
-        val day = backStackEntry.arguments?.getInt("day") ?: 0
-        val from = backStackEntry.arguments?.getString("from") ?: "write_diary" // from 파라미터 가져오기
-        ReplyLoadingRoute(replyLoadingNavigator, year, month, day, from)
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/navigation/WriteDiaryNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/navigation/WriteDiaryNavigator.kt
@@ -11,6 +11,6 @@ class WriteDiaryNavigator(
     }
 
     fun navigateBack() {
-        navController.popBackStack()
+        navController.navigateUp()
     }
 }


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #121 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- "캘린더 > 리스트" 캘린더에서 피커로 선택한 연,월에 대한 모아보기를 제공
- "리스트 > 캘린더" 리스트에서 사용자가 피커로 마지막으로 선택한 연,월에 대한 캘린더를 제공 

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 캘린더 <-> 리스트 간에 1차적 이동 간에는 문제가 없는 것으로 판단을 했었는데 그 외 다른 뷰들에서 올때 이슈가 발생했습니다..현재 제가 작성한 코드를 기준으로는 이런식의 플로우를 기대했습니다.
   - `SignUp`,`Guide`로부터 접근 : 현재 날짜 기준 캘린더 제공
   - `DiaryList`로부터 접근 : 사용자가 피커로 선택한 마지막 연,월 기준 캘린더 제공
   - `ReplyLoading`, `ReplyDiary`로부터 접근 : 답장의 날짜 기준 캘린더 제공
   - `Setting`, `WriteDiary` 로부터 접근 : 뒤로가기 이용 (=사용자가 피커로 선택한 마지막 연,월 기준 캘린더 제공 )

하지만 지금 발생한 이슈는 이러합니다.
리스트에서 연,월 값 변경(값1) -> 캘린더에서 연,월 값 변경(값2) -> 해당 값(값2)의 캘린더 안에서 일기 작성이나 답장 로딩 페이지로 이동 -> 캘린더로 복귀 시 리스트에서 선택한 값(값1)에 대한 캘린더 제공 
한번 봐주시면 감사하겠습니다 ㅠㅠㅠ..


## 📸 스크린샷/동영상
디코로 보신 그대로입니다.. ㅠ