### PR TITLE
[REFACTOR/#132] 일기모아보기 페이지 Route, Screen 개선

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/FailureScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/FailureScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +19,7 @@ fun FailureScreen() {
         contentAlignment = Alignment.Center
     ) {
         Button(
-            onClick = { /* TODO : 재시도 액션 */},
+            onClick = { /* TODO : 재시도 액션 */ },
             modifier = Modifier
                 .wrapContentSize(Alignment.Center),
             colors = ButtonDefaults.buttonColors(ClodyTheme.colors.gray05)
@@ -39,4 +38,3 @@ fun FailureScreen() {
 fun showFailureScreen() {
     FailureScreen()
 }
-

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/bottomsheet/DiaryDeleteSheet.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/bottomsheet/DiaryDeleteSheet.kt
@@ -26,14 +26,14 @@ import com.sopt.clody.ui.theme.ClodyTheme
 @Composable
 fun DiaryDeleteSheet(
     onDismiss: () -> Unit,
-    onShowDiaryDeleteDialogStateChange: (Boolean) -> Unit
+    showDiaryDeleteDialog: () -> Unit
 ) {
     ClodyBottomSheet(
         onDismissRequest = onDismiss,
         content = {
             DiaryDeleteBottomSheetItem(
                 onDismiss = onDismiss,
-                onShowDiaryDeleteDialogStateChange = onShowDiaryDeleteDialogStateChange
+                showDiaryDeleteDialog = showDiaryDeleteDialog
             )
         }
     )
@@ -42,7 +42,7 @@ fun DiaryDeleteSheet(
 @Composable
 fun DiaryDeleteBottomSheetItem(
     onDismiss: () -> Unit,
-    onShowDiaryDeleteDialogStateChange: (Boolean) -> Unit,
+    showDiaryDeleteDialog: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -58,7 +58,7 @@ fun DiaryDeleteBottomSheetItem(
                 .clip(RoundedCornerShape(10.dp))
                 .clickable {
                     onDismiss()
-                    onShowDiaryDeleteDialogStateChange(true)
+                    showDiaryDeleteDialog()
                 }
                 .padding(start = 24.dp)
         ) {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -210,5 +210,14 @@ fun ReplyDiaryButton(
     }
 }
 
-    return LocalDate.of(year, month, day).dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
+@Composable
+fun DiaryDeleteButton(
+    showDiaryDeleteBottomSheet: () -> Unit
+) {
+    Image(
+        painter = painterResource(id = R.drawable.ic_listview_kebab_menu),
+        contentDescription = "kebab menu",
+        modifier = Modifier
+            .clickable(onClick = showDiaryDeleteBottomSheet)
+    )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -49,12 +49,7 @@ fun DailyDiaryCard(
         else -> R.drawable.ic_home_ungiven_clover
     }
 
-    val diaryDay = dailyDiary.date.split("-")
-    val year = diaryDay[0].toInt()
-    val month = diaryDay[1].toInt()
-    val day = diaryDay[2].toInt()
-    val dayOfWeek = getDayOfWeek(year, month, day)
-    diaryListViewModel.setSelectedDiaryDate(year, month, day)
+    diaryListViewModel.setSelectedDiaryDate(selectedDiaryDate = dailyDiary.date)
 
     Card(
         modifier = Modifier
@@ -75,8 +70,7 @@ fun DailyDiaryCard(
                     .wrapContentHeight()
                     .padding(start = 20.dp, end = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
-            )
-            {
+            ) {
                 Image(
                     painter = painterResource(id = iconRes),
                     contentDescription = "clover",
@@ -84,14 +78,14 @@ fun DailyDiaryCard(
                         .padding(end = 6.dp)
                 )
                 Text(
-                    text = stringResource(R.string.diarylist_daily_diary_day, day),
+                    text = stringResource(R.string.diarylist_daily_diary_day, diaryListViewModel.selectedDiaryDay),
                     modifier = Modifier
                         .padding(end = 2.dp),
                     color = ClodyTheme.colors.gray01,
                     style = ClodyTheme.typography.body1SemiBold
                 )
                 Text(
-                    text = stringResource(R.string.diarylist_daily_diary_day_of_week, dayOfWeek),
+                    text = stringResource(R.string.diarylist_daily_diary_day_of_week, diaryListViewModel.selectedDiaryDayOfWeek),
                     color = ClodyTheme.colors.gray04,
                     style = ClodyTheme.typography.body2SemiBold
                 )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -63,6 +63,7 @@ fun DailyDiaryCard(
     val month = diaryDay[1].toInt()
     val day = diaryDay[2].toInt()
     val dayOfWeek = getDayOfWeek(dailyDiary.date)
+    val dayOfWeek = getDayOfWeek(year, month, day)
 
     Card(
         modifier = Modifier

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -20,10 +20,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -31,23 +27,18 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.sopt.clody.R
 import com.sopt.clody.data.remote.dto.response.ResponseMonthlyDiaryDto
-import com.sopt.clody.presentation.ui.component.bottomsheet.DiaryDeleteSheet
-import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
+import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListViewModel
+import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import com.sopt.clody.ui.theme.ClodyTheme
-import java.time.LocalDate
-import java.time.format.TextStyle
-import java.util.Locale
 
 @Composable
 fun DailyDiaryCard(
     index: Int,
+    diaryListViewModel: DiaryListViewModel,
     dailyDiary: ResponseMonthlyDiaryDto.DailyDiary,
-    onClickReplyDiary: (Int, Int, Int) -> Unit,
-    onDeleteDiary: (Int, Int, Int) -> Unit
+    showDiaryDeleteBottomSheet: () -> Unit,
+    onClickReplyDiary: () -> Unit,
 ) {
-    var showDiaryDeleteSheet by remember { mutableStateOf(false) }
-    var showDiaryDeleteDialog by remember { mutableStateOf(false) }
-
     val iconRes = when {
         dailyDiary.replyStatus == "READY_NOT_READ" && dailyDiary.diaryCount > 0 -> R.drawable.ic_home_ungiven_clover
         dailyDiary.replyStatus == "UNREADY" && dailyDiary.diaryCount > 0 -> R.drawable.ic_home_ungiven_clover
@@ -106,68 +97,17 @@ fun DailyDiaryCard(
                     style = ClodyTheme.typography.body2SemiBold
                 )
                 Spacer(modifier = Modifier.weight(1f))
-                Box(
-                    contentAlignment = Alignment.TopEnd
-                ) {
-                    Button(
-                        modifier = Modifier
-                            .height(33.dp)
-                            .padding(horizontal = 3.dp, vertical = 3.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = ClodyTheme.colors.lightBlue),
-                        shape = RoundedCornerShape(size = 9.dp),
-                        onClick = { onClickReplyDiary(year, month, day) },
-                        contentPadding = PaddingValues(0.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.diarylist_check_reply),
-                            modifier = Modifier
-                                .padding(horizontal = 10.dp, vertical = 2.dp),
-                            style = ClodyTheme.typography.detail1SemiBold,
-                            color = ClodyTheme.colors.blue
-                        )
-                    }
-                    if (dailyDiary.replyStatus == "READY_NOT_READ") {
-                        Image(
-                            painter = painterResource(id = R.drawable.ic_reply_diary_new),
-                            modifier = Modifier
-                                .align(Alignment.TopEnd),
-                            contentDescription = null,
-                        )
-                    }
-                }
-                Image(
-                    painter = painterResource(id = R.drawable.ic_listview_kebab_menu),
-                    contentDescription = "kebab menu",
-                    modifier = Modifier
-                        .clickable(onClick = { showDiaryDeleteSheet = true })
+                ReplyDiaryButton(
+                    dailyDiary = dailyDiary,
+                    onClickReplyDiary = onClickReplyDiary,
+                )
+                DiaryDeleteButton(
+                    showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet
                 )
             }
             Spacer(modifier = Modifier.height(12.dp))
-            DailyDiaryCardItem(dailyDiary.diary.map { it.content })
+            DailyDiaryCardContent(dailyDiary.diary.map { it.content })
         }
-    }
-
-    if (showDiaryDeleteSheet) {
-        DiaryDeleteSheet(
-            onDismiss = { showDiaryDeleteSheet = false },
-            onShowDiaryDeleteDialogStateChange = { newState -> showDiaryDeleteDialog = newState }
-        )
-    }
-
-    if (showDiaryDeleteDialog) {
-        ClodyDialog(
-            titleMassage = stringResource(R.string.delete_diary_dialog_title),
-            descriptionMassage = stringResource(R.string.delete_diary_dialog_description),
-            confirmOption = stringResource(R.string.delete_diary_dialog_confirm_option),
-            dismissOption = stringResource(R.string.delete_diary_dialog_dismiss_option),
-            confirmAction = {
-                onDeleteDiary(year, month, day)
-                showDiaryDeleteDialog = false
-            },
-            onDismiss = { showDiaryDeleteDialog = false },
-            confirmButtonColor = ClodyTheme.colors.red,
-            confirmButtonTextColor = ClodyTheme.colors.white
-        )
     }
 }
 

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -36,8 +35,12 @@ fun DailyDiaryCard(
     index: Int,
     diaryListViewModel: DiaryListViewModel,
     dailyDiary: ResponseMonthlyDiaryDto.DailyDiary,
+    year: Int,
+    month: Int,
+    day: Int,
+    dayOfWeek: String,
     showDiaryDeleteBottomSheet: () -> Unit,
-    onClickReplyDiary: () -> Unit,
+    onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
     val iconRes = when {
         dailyDiary.replyStatus == "READY_NOT_READ" && dailyDiary.diaryCount > 0 -> R.drawable.ic_home_ungiven_clover
@@ -48,8 +51,6 @@ fun DailyDiaryCard(
         dailyDiary.diaryCount == 5 -> R.drawable.ic_home_top_clover
         else -> R.drawable.ic_home_ungiven_clover
     }
-
-    diaryListViewModel.setSelectedDiaryDate(selectedDiaryDate = dailyDiary.date)
 
     Card(
         modifier = Modifier
@@ -81,14 +82,14 @@ fun DailyDiaryCard(
                     verticalAlignment = Alignment.Bottom
                 ) {
                     Text(
-                        text = stringResource(R.string.diarylist_daily_diary_day, diaryListViewModel.selectedDiaryDay.collectAsState().value),
+                        text = stringResource(R.string.diarylist_daily_diary_day, day),
                         modifier = Modifier
                             .padding(end = 2.dp),
                         color = ClodyTheme.colors.gray01,
                         style = ClodyTheme.typography.body1SemiBold
                     )
                     Text(
-                        text = stringResource(R.string.diarylist_daily_diary_day_of_week, diaryListViewModel.selectedDiaryDayOfWeek.collectAsState().value),
+                        text = stringResource(R.string.diarylist_daily_diary_day_of_week, dayOfWeek),
                         color = ClodyTheme.colors.gray04,
                         style = ClodyTheme.typography.body2SemiBold
                     )
@@ -96,9 +97,14 @@ fun DailyDiaryCard(
                 Spacer(modifier = Modifier.weight(1f))
                 ReplyDiaryButton(
                     dailyDiary = dailyDiary,
+                    year = year,
+                    month = month,
+                    day = day,
                     onClickReplyDiary = onClickReplyDiary,
                 )
                 DiaryDeleteButton(
+                    diaryListViewModel = diaryListViewModel,
+                    dailyDiary = dailyDiary,
                     showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet
                 )
             }
@@ -110,13 +116,16 @@ fun DailyDiaryCard(
 @Composable
 fun ReplyDiaryButton(
     dailyDiary: ResponseMonthlyDiaryDto.DailyDiary,
-    onClickReplyDiary: () -> Unit,
+    year: Int,
+    month: Int,
+    day: Int,
+    onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
     Box(
         contentAlignment = Alignment.TopEnd
     ) {
         Button(
-            onClick = onClickReplyDiary,
+            onClick = { onClickReplyDiary(year,month,day) },
             modifier = Modifier
                 .height(33.dp)
                 .padding(horizontal = 3.dp, vertical = 3.dp),
@@ -150,12 +159,19 @@ fun ReplyDiaryButton(
 
 @Composable
 fun DiaryDeleteButton(
+    diaryListViewModel: DiaryListViewModel,
+    dailyDiary: ResponseMonthlyDiaryDto.DailyDiary,
     showDiaryDeleteBottomSheet: () -> Unit
 ) {
     Image(
         painter = painterResource(id = R.drawable.ic_listview_kebab_menu),
         contentDescription = "kebab menu",
         modifier = Modifier
-            .clickable(onClick = showDiaryDeleteBottomSheet)
+            .clickable(
+                onClick = {
+                    diaryListViewModel.setSelectedDiaryDate(dailyDiary.date)
+                    showDiaryDeleteBottomSheet()
+                }
+            )
     )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -67,8 +67,7 @@ fun DailyDiaryCard(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 20.dp)
-                .padding(bottom = 8.dp)
+                .padding(vertical = 20.dp)
         ) {
             Row(
                 modifier = Modifier
@@ -105,7 +104,6 @@ fun DailyDiaryCard(
                     showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
             DailyDiaryCardContent(dailyDiary.diary.map { it.content })
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -28,7 +29,6 @@ import androidx.compose.ui.unit.dp
 import com.sopt.clody.R
 import com.sopt.clody.data.remote.dto.response.ResponseMonthlyDiaryDto
 import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListViewModel
-import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import com.sopt.clody.ui.theme.ClodyTheme
 
 @Composable
@@ -68,7 +68,7 @@ fun DailyDiaryCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight()
-                    .padding(start = 20.dp, end = 12.dp),
+                    .padding(start = 20.dp, end = 12.dp, bottom = 18.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Image(
@@ -77,18 +77,22 @@ fun DailyDiaryCard(
                     modifier = Modifier
                         .padding(end = 6.dp)
                 )
-                Text(
-                    text = stringResource(R.string.diarylist_daily_diary_day, diaryListViewModel.selectedDiaryDay),
-                    modifier = Modifier
-                        .padding(end = 2.dp),
-                    color = ClodyTheme.colors.gray01,
-                    style = ClodyTheme.typography.body1SemiBold
-                )
-                Text(
-                    text = stringResource(R.string.diarylist_daily_diary_day_of_week, diaryListViewModel.selectedDiaryDayOfWeek),
-                    color = ClodyTheme.colors.gray04,
-                    style = ClodyTheme.typography.body2SemiBold
-                )
+                Row(
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    Text(
+                        text = stringResource(R.string.diarylist_daily_diary_day, diaryListViewModel.selectedDiaryDay.collectAsState().value),
+                        modifier = Modifier
+                            .padding(end = 2.dp),
+                        color = ClodyTheme.colors.gray01,
+                        style = ClodyTheme.typography.body1SemiBold
+                    )
+                    Text(
+                        text = stringResource(R.string.diarylist_daily_diary_day_of_week, diaryListViewModel.selectedDiaryDayOfWeek.collectAsState().value),
+                        color = ClodyTheme.colors.gray04,
+                        style = ClodyTheme.typography.body2SemiBold
+                    )
+                }
                 Spacer(modifier = Modifier.weight(1f))
                 ReplyDiaryButton(
                     dailyDiary = dailyDiary,
@@ -112,14 +116,18 @@ fun ReplyDiaryButton(
         contentAlignment = Alignment.TopEnd
     ) {
         Button(
+            onClick = onClickReplyDiary,
             modifier = Modifier
                 .height(33.dp)
                 .padding(horizontal = 3.dp, vertical = 3.dp),
-            colors =
-            if (dailyDiary.replyStatus == "UNREADY") ButtonDefaults.buttonColors(containerColor = ClodyTheme.colors.gray04)
-            else ButtonDefaults.buttonColors(containerColor = ClodyTheme.colors.lightBlue),
+            enabled = dailyDiary.replyStatus != "UNREADY",
+            colors = ButtonDefaults.buttonColors(
+                containerColor = ClodyTheme.colors.lightBlue,
+                contentColor = ClodyTheme.colors.blue,
+                disabledContainerColor = ClodyTheme.colors.gray08,
+                disabledContentColor = ClodyTheme.colors.gray06
+            ),
             shape = RoundedCornerShape(size = 9.dp),
-            onClick = onClickReplyDiary,
             contentPadding = PaddingValues(0.dp),
         ) {
             Text(
@@ -127,9 +135,6 @@ fun ReplyDiaryButton(
                 modifier = Modifier
                     .padding(horizontal = 10.dp, vertical = 2.dp),
                 style = ClodyTheme.typography.detail1SemiBold,
-                color =
-                if (dailyDiary.replyStatus == "UNREADY") ClodyTheme.colors.gray02
-                else ClodyTheme.colors.blue
             )
         }
         if (dailyDiary.replyStatus == "READY_NOT_READ") {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -170,11 +170,45 @@ fun DailyDiaryCard(
     }
 }
 
-fun getDayOfWeek(dateString: String): String {
-    val parts = dateString.split("-")
-    val year = parts[0].toInt()
-    val month = parts[1].toInt()
-    val day = parts[2].toInt()
+@Composable
+fun ReplyDiaryButton(
+    dailyDiary: ResponseMonthlyDiaryDto.DailyDiary,
+    onClickReplyDiary: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.TopEnd
+    ) {
+        Button(
+            modifier = Modifier
+                .height(33.dp)
+                .padding(horizontal = 3.dp, vertical = 3.dp),
+            colors =
+            if (dailyDiary.replyStatus == "UNREADY") ButtonDefaults.buttonColors(containerColor = ClodyTheme.colors.gray04)
+            else ButtonDefaults.buttonColors(containerColor = ClodyTheme.colors.lightBlue),
+            shape = RoundedCornerShape(size = 9.dp),
+            onClick = onClickReplyDiary,
+            contentPadding = PaddingValues(0.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.diarylist_check_reply),
+                modifier = Modifier
+                    .padding(horizontal = 10.dp, vertical = 2.dp),
+                style = ClodyTheme.typography.detail1SemiBold,
+                color =
+                if (dailyDiary.replyStatus == "UNREADY") ClodyTheme.colors.gray02
+                else ClodyTheme.colors.blue
+            )
+        }
+        if (dailyDiary.replyStatus == "READY_NOT_READ") {
+            Image(
+                painter = painterResource(id = R.drawable.ic_reply_diary_new),
+                modifier = Modifier
+                    .align(Alignment.TopEnd),
+                contentDescription = null,
+            )
+        }
+    }
+}
 
     return LocalDate.of(year, month, day).dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -62,8 +62,8 @@ fun DailyDiaryCard(
     val year = diaryDay[0].toInt()
     val month = diaryDay[1].toInt()
     val day = diaryDay[2].toInt()
-    val dayOfWeek = getDayOfWeek(dailyDiary.date)
     val dayOfWeek = getDayOfWeek(year, month, day)
+    diaryListViewModel.setSelectedDiaryDate(year, month, day)
 
     Card(
         modifier = Modifier

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCardContent.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCardContent.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.sopt.clody.ui.theme.ClodyTheme
 
 @Composable
-fun DailyDiaryCardItem(
+fun DailyDiaryCardContent(
     diary: List<String>
 ) {
     Column(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DiaryListTopAppBar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DiaryListTopAppBar.kt
@@ -27,10 +27,10 @@ import com.sopt.clody.ui.theme.ClodyTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiaryListTopAppBar(
-    onClickCalendar: () -> Unit,
     selectedYear: Int,
     selectedMonth: Int,
-    updateYearMonthPicker: (Boolean) -> Unit,
+    showYearMonthPicker: () -> Unit,
+    onClickCalendar: () -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 
@@ -40,7 +40,7 @@ fun DiaryListTopAppBar(
                 Row(
                     modifier = Modifier
                         .padding(start = 16.dp)
-                        .clickable(onClick = { updateYearMonthPicker(true) }),
+                        .clickable(onClick = showYearMonthPicker),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DiaryListTopAppBar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DiaryListTopAppBar.kt
@@ -1,11 +1,14 @@
 package com.sopt.clody.presentation.ui.diarylist.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
@@ -27,41 +30,49 @@ fun DiaryListTopAppBar(
     onClickCalendar: () -> Unit,
     selectedYear: Int,
     selectedMonth: Int,
-    onShowYearMonthPickerStateChange: (Boolean) -> Unit,
+    updateYearMonthPicker: (Boolean) -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 
-    CenterAlignedTopAppBar(
-        title = {
-            Row(
-                modifier = Modifier
-                    .padding(start = 16.dp)
-                    .clickable(onClick = { onShowYearMonthPickerStateChange(true) }),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.diarylist_selected_year_month, selectedYear, selectedMonth),
-                    color = ClodyTheme.colors.gray01,
-                    style = ClodyTheme.typography.head4
-                )
-                Image(
-                    painter = painterResource(id = R.drawable.ic_listview_arrow_down),
-                    contentDescription = null
-                )
-            }
-        },
-        navigationIcon = {
-            IconButton(
-                onClick = onClickCalendar,
-                modifier = Modifier.padding(start = 8.dp)
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_listview_calendar),
-                    contentDescription = "go to calenderView"
-                )
-            }
-        },
-        colors = TopAppBarDefaults.topAppBarColors(ClodyTheme.colors.white),
-        scrollBehavior = scrollBehavior,
-    )
+    Column {
+        CenterAlignedTopAppBar(
+            title = {
+                Row(
+                    modifier = Modifier
+                        .padding(start = 16.dp)
+                        .clickable(onClick = { updateYearMonthPicker(true) }),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.diarylist_selected_year_month, selectedYear, selectedMonth),
+                        color = ClodyTheme.colors.gray01,
+                        style = ClodyTheme.typography.head4
+                    )
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_listview_arrow_down),
+                        contentDescription = null
+                    )
+                }
+            },
+            navigationIcon = {
+                IconButton(
+                    onClick = onClickCalendar,
+                    modifier = Modifier.padding(start = 8.dp)
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_listview_calendar),
+                        contentDescription = "go to calenderView"
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(ClodyTheme.colors.white),
+            scrollBehavior = scrollBehavior,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(ClodyTheme.colors.gray07)
+        )
+    }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/MonthlyDiaryList.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/MonthlyDiaryList.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.sopt.clody.data.remote.dto.response.ResponseMonthlyDiaryDto
 import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListViewModel
+import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 
 @Composable
 fun MonthlyDiaryList(
@@ -17,7 +18,7 @@ fun MonthlyDiaryList(
     diaryListViewModel: DiaryListViewModel,
     diaries: List<ResponseMonthlyDiaryDto.DailyDiary>,
     showDiaryDeleteBottomSheet: () -> Unit,
-    onClickReplyDiary: () -> Unit,
+    onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier
@@ -26,10 +27,19 @@ fun MonthlyDiaryList(
             .padding(top = 18.dp)
     ) {
         itemsIndexed(items = diaries) { index, dailyDiary ->
+            val date = dailyDiary.date.split("-")
+            val year = date[0].toInt()
+            val month = date[1].toInt()
+            val day = date[2].toInt()
+            val dayOfWeek = getDayOfWeek(year, month, day)
             DailyDiaryCard(
                 index = index,
                 diaryListViewModel = diaryListViewModel,
                 dailyDiary = dailyDiary,
+                year = year,
+                month = month,
+                day = day,
+                dayOfWeek = dayOfWeek,
                 showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet,
                 onClickReplyDiary = onClickReplyDiary
             )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/MonthlyDiaryList.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/MonthlyDiaryList.kt
@@ -14,9 +14,10 @@ import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListViewModel
 @Composable
 fun MonthlyDiaryList(
     paddingValues: PaddingValues,
-    onClickReplyDiary: (Int, Int, Int) -> Unit,
+    diaryListViewModel: DiaryListViewModel,
     diaries: List<ResponseMonthlyDiaryDto.DailyDiary>,
-    diaryListViewModel: DiaryListViewModel
+    showDiaryDeleteBottomSheet: () -> Unit,
+    onClickReplyDiary: () -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier
@@ -24,14 +25,13 @@ fun MonthlyDiaryList(
             .padding(paddingValues)
             .padding(top = 18.dp)
     ) {
-        itemsIndexed(diaries) { index, dailyDiary ->
+        itemsIndexed(items = diaries) { index, dailyDiary ->
             DailyDiaryCard(
                 index = index,
+                diaryListViewModel = diaryListViewModel,
                 dailyDiary = dailyDiary,
-                onClickReplyDiary = onClickReplyDiary,
-                onDeleteDiary = { year, month, day ->
-                    diaryListViewModel.deleteDailyDiary(year, month, day)
-                }
+                showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet,
+                onClickReplyDiary = onClickReplyDiary
             )
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/navigation/DiaryListNavGraph.kt
@@ -1,10 +1,10 @@
 package com.sopt.clody.presentation.ui.diarylist.navigation
 
-import DiaryListRoute
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListRoute
 import java.time.LocalDate
 
 fun NavGraphBuilder.diaryListNavGraph(
@@ -12,7 +12,7 @@ fun NavGraphBuilder.diaryListNavGraph(
 ) {
     composable(
         route = "diary_list/{selectedYearFromHome}/{selectedMonthFromHome}",
-        arguments = listOf(
+        arguments = listOf (
             navArgument("selectedYearFromHome") { type = NavType.IntType },
             navArgument("selectedMonthFromHome") { type = NavType.IntType }
         )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryListState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryListState.kt
@@ -1,8 +1,0 @@
-package com.sopt.clody.presentation.ui.diarylist.screen
-
-sealed class DeleteDiaryListState {
-    data object Idle : DeleteDiaryListState()
-    data object Loading : DeleteDiaryListState()
-    data object Success : DeleteDiaryListState()
-    data class Failure(val errorMessage: String) : DeleteDiaryListState()
-}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryListState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryListState.kt
@@ -1,8 +1,8 @@
 package com.sopt.clody.presentation.ui.diarylist.screen
 
 sealed class DeleteDiaryListState {
-    object Idle : DeleteDiaryListState()
-    object Loading : DeleteDiaryListState()
-    object Success : DeleteDiaryListState()
+    data object Idle : DeleteDiaryListState()
+    data object Loading : DeleteDiaryListState()
+    data object Success : DeleteDiaryListState()
     data class Failure(val errorMessage: String) : DeleteDiaryListState()
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryState.kt
@@ -1,0 +1,8 @@
+package com.sopt.clody.presentation.ui.diarylist.screen
+
+sealed class DeleteDiaryState {
+    data object Idle : DeleteDiaryState()
+    data object Loading : DeleteDiaryState()
+    data object Success : DeleteDiaryState()
+    data class Failure(val errorMessage: String) : DeleteDiaryState()
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DeleteDiaryState.kt
@@ -1,8 +1,0 @@
-package com.sopt.clody.presentation.ui.diarylist.screen
-
-sealed class DeleteDiaryState {
-    data object Idle : DeleteDiaryState()
-    data object Loading : DeleteDiaryState()
-    data object Success : DeleteDiaryState()
-    data class Failure(val errorMessage: String) : DeleteDiaryState()
-}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryDeleteState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryDeleteState.kt
@@ -1,0 +1,8 @@
+package com.sopt.clody.presentation.ui.diarylist.screen
+
+sealed class DiaryDeleteState {
+    data object Idle : DiaryDeleteState()
+    data object Loading : DiaryDeleteState()
+    data object Success : DiaryDeleteState()
+    data class Failure(val errorMessage: String) : DiaryDeleteState()
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -49,10 +49,7 @@ fun DiaryListRoute(
         diaryListViewModel = diaryListViewModel,
         selectedYearInDiaryList = selectedYearInDiaryList,
         selectedMonthInDiaryList = selectedMonthInDiaryList,
-        updateYearAndMonth = { newYear, newMonth ->
-            selectedYearInDiaryList = newYear
-            selectedMonthInDiaryList = newMonth
-        },
+        updateYearAndMonth = { newYear, newMonth -> selectedYearInDiaryList = newYear; selectedMonthInDiaryList = newMonth },
         diaryListState = diaryListState,
         diaryDeleteState = diaryDeleteState,
         yearMonthPickerState = yearMonthPickerState,
@@ -64,7 +61,7 @@ fun DiaryListRoute(
         diaryDeleteDialogState = diaryDeleteDialogState,
         showDiaryDeleteDialog = { diaryDeleteDialogState = true },
         dismissDiaryDeleteDialog = { diaryDeleteDialogState = false },
-        onClickDiaryDelete = { diaryListViewModel.deleteDailyDiary(selectedDiaryYear,selectedDiaryMonth,selectedDiaryDay) },
+        onClickDiaryDelete = { diaryListViewModel.deleteDailyDiary(selectedDiaryYear, selectedDiaryMonth, selectedDiaryDay) },
         onClickCalendar = { navigator.navigateHome(selectedYearInDiaryList, selectedMonthInDiaryList) },
         onClickReplyDiary = { navigator.navigateReplyLoading(selectedDiaryYear, selectedDiaryMonth, selectedDiaryDay) }
     )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -33,9 +33,7 @@ fun DiaryListRoute(
     var selectedYearInDiaryList by remember { mutableIntStateOf(selectedYearFromHome) }
     var selectedMonthInDiaryList by remember { mutableIntStateOf(selectedMonthFromHome) }
     val diaryListState by diaryListViewModel.diaryListState.collectAsState()
-    val selectedDiaryYear by diaryListViewModel.selectedDiaryYear.collectAsState()
-    val selectedDiaryMonth by diaryListViewModel.selectedDiaryMonth.collectAsState()
-    val selectedDiaryDay by diaryListViewModel.selectedDiaryDay.collectAsState()
+    val selectedDiaryDate by diaryListViewModel.selectedDiaryDate.collectAsState()
     val diaryDeleteState by diaryListViewModel.diaryDeleteState.collectAsState()
     var yearMonthPickerState by remember { mutableStateOf(false) }
     var diaryDeleteBottomSheetState by remember { mutableStateOf(false) }
@@ -51,6 +49,7 @@ fun DiaryListRoute(
         selectedMonthInDiaryList = selectedMonthInDiaryList,
         updateYearAndMonth = { newYear, newMonth -> selectedYearInDiaryList = newYear; selectedMonthInDiaryList = newMonth },
         diaryListState = diaryListState,
+        selectedDiaryDate = selectedDiaryDate,
         diaryDeleteState = diaryDeleteState,
         yearMonthPickerState = yearMonthPickerState,
         showYearMonthPicker = { yearMonthPickerState = true },
@@ -61,9 +60,9 @@ fun DiaryListRoute(
         diaryDeleteDialogState = diaryDeleteDialogState,
         showDiaryDeleteDialog = { diaryDeleteDialogState = true },
         dismissDiaryDeleteDialog = { diaryDeleteDialogState = false },
-        onClickDiaryDelete = { diaryListViewModel.deleteDailyDiary(selectedDiaryYear, selectedDiaryMonth, selectedDiaryDay) },
+        onClickDiaryDelete = { year, month, day -> diaryListViewModel.deleteDailyDiary(year, month, day) },
         onClickCalendar = { navigator.navigateHome(selectedYearInDiaryList, selectedMonthInDiaryList) },
-        onClickReplyDiary = { navigator.navigateReplyLoading(selectedDiaryYear, selectedDiaryMonth, selectedDiaryDay) }
+        onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) }
     )
 }
 
@@ -74,6 +73,7 @@ fun DiaryListScreen(
     selectedMonthInDiaryList: Int,
     updateYearAndMonth: (Int, Int) -> Unit,
     diaryListState: DiaryListState,
+    selectedDiaryDate: DiaryListViewModel.DiaryDate,
     diaryDeleteState: DiaryDeleteState,
     yearMonthPickerState: Boolean,
     showYearMonthPicker: () -> Unit,
@@ -84,9 +84,9 @@ fun DiaryListScreen(
     diaryDeleteDialogState: Boolean,
     showDiaryDeleteDialog: () -> Unit,
     dismissDiaryDeleteDialog: () -> Unit,
-    onClickDiaryDelete: () -> Unit,
+    onClickDiaryDelete: (Int, Int, Int) -> Unit,
     onClickCalendar: () -> Unit,
-    onClickReplyDiary: () -> Unit,
+    onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -172,7 +172,7 @@ fun DiaryListScreen(
             confirmOption = stringResource(R.string.diary_delete_dialog_confirm_option),
             dismissOption = stringResource(R.string.diary_delete_dialog_dismiss_option),
             confirmAction = {
-                onClickDiaryDelete()
+                onClickDiaryDelete(selectedDiaryDate.year, selectedDiaryDate.month, selectedDiaryDate.day)
                 dismissDiaryDeleteDialog()
             },
             onDismiss = dismissDiaryDeleteDialog,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -1,12 +1,5 @@
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.CircularProgressIndicator
+package com.sopt.clody.presentation.ui.diarylist.screen
+
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -16,19 +9,14 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.clody.presentation.ui.component.FailureScreen
+import com.sopt.clody.presentation.ui.component.LoadingScreen
 import com.sopt.clody.presentation.ui.component.popup.ClodyPopupBottomSheet
 import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.diarylist.component.DiaryListTopAppBar
 import com.sopt.clody.presentation.ui.diarylist.component.MonthlyDiaryList
 import com.sopt.clody.presentation.ui.diarylist.navigation.DiaryListNavigator
-import com.sopt.clody.presentation.ui.diarylist.screen.DeleteDiaryListState
-import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListState
-import com.sopt.clody.presentation.ui.diarylist.screen.DiaryListViewModel
-import com.sopt.clody.presentation.utils.extension.showToast
 import com.sopt.clody.ui.theme.ClodyTheme
 
 @Composable
@@ -38,10 +26,28 @@ fun DiaryListRoute(
     selectedYearFromHome: Int,
     selectedMonthFromHome: Int
 ) {
+    var selectedYearInDiaryList by remember { mutableIntStateOf(selectedYearFromHome) }
+    var selectedMonthInDiaryList by remember { mutableIntStateOf(selectedMonthFromHome) }
+    val diaryListState by diaryListViewModel.diaryListState.collectAsState()
+    val deleteDiaryResult by diaryListViewModel.deleteDiaryResult.collectAsState()
+    var showYearMonthPicker by remember { mutableStateOf(false) }
+
+    LaunchedEffect(selectedYearInDiaryList, selectedMonthInDiaryList) {
+        diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
+    }
+
     DiaryListScreen(
         diaryListViewModel = diaryListViewModel,
-        selectedYearFromHome = selectedYearFromHome,
-        selectedMonthFromHome = selectedMonthFromHome,
+        selectedYearInDiaryList = selectedYearInDiaryList,
+        selectedMonthInDiaryList = selectedMonthInDiaryList,
+        updateYearAndMonth = { newYear, newMonth ->
+            selectedYearInDiaryList = newYear
+            selectedMonthInDiaryList = newMonth
+        },
+        diaryListState = diaryListState,
+        deleteDiaryResult = deleteDiaryResult,
+        showYearMonthPicker = showYearMonthPicker,
+        updateYearMonthPicker = { state -> showYearMonthPicker = state },
         onClickCalendar = { selectedYearFromDiaryList, selectedMonthFromDiaryList -> navigator.navigateHome(selectedYearFromDiaryList, selectedMonthFromDiaryList) },
         onClickReplyDiary = { year, month, day -> navigator.navigateReplyLoading(year, month, day) }
     )
@@ -50,100 +56,79 @@ fun DiaryListRoute(
 @Composable
 fun DiaryListScreen(
     diaryListViewModel: DiaryListViewModel,
-    selectedYearFromHome: Int,
-    selectedMonthFromHome: Int,
+    selectedYearInDiaryList: Int,
+    selectedMonthInDiaryList: Int,
+    updateYearAndMonth: (Int, Int) -> Unit,
+    diaryListState: DiaryListState,
+    deleteDiaryResult: DeleteDiaryListState,
+    showYearMonthPicker: Boolean,
+    updateYearMonthPicker: (Boolean) -> Unit,
     onClickCalendar: (Int, Int) -> Unit,
     onClickReplyDiary: (Int, Int, Int) -> Unit,
 ) {
-    var showYearMonthPickerState by remember { mutableStateOf(false) }
-    var selectedYearInDiaryList by remember { mutableIntStateOf(selectedYearFromHome) }
-    var selectedMonthInDiaryList by remember { mutableIntStateOf(selectedMonthFromHome) }
-    val diaryListState by diaryListViewModel.diaryListState.collectAsState()
-    val deleteDiaryResult by diaryListViewModel.deleteDiaryResult.collectAsState()
-
-    val onYearMonthSelected: (Int, Int) -> Unit = { year, month ->
-        selectedYearInDiaryList = year
-        selectedMonthInDiaryList = month
-    }
-
-    LaunchedEffect(selectedYearInDiaryList, selectedMonthInDiaryList) {
-        diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
-    }
-
-    when (deleteDiaryResult) {
-        is DeleteDiaryListState.Loading -> {
-        }
-
-        is DeleteDiaryListState.Success -> {
-            LaunchedEffect(Unit) {
-                diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
-            }
-        }
-
-        is DeleteDiaryListState.Failure -> {
-        }
-
-        else -> {}
-    }
-
     Scaffold(
         topBar = {
-            Column {
-                DiaryListTopAppBar(
-                    onClickCalendar = { onClickCalendar(selectedYearInDiaryList, selectedMonthInDiaryList) },
-                    selectedYear = selectedYearInDiaryList,
-                    selectedMonth = selectedMonthInDiaryList,
-                    onShowYearMonthPickerStateChange = { newState -> showYearMonthPickerState = newState }
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                        .background(ClodyTheme.colors.gray07)
-                )
-            }
+            DiaryListTopAppBar(
+                onClickCalendar = { onClickCalendar(selectedYearInDiaryList, selectedMonthInDiaryList) },
+                selectedYear = selectedYearInDiaryList,
+                selectedMonth = selectedMonthInDiaryList,
+                updateYearMonthPicker = updateYearMonthPicker
+            )
         },
         containerColor = ClodyTheme.colors.gray08,
         content = { innerPadding ->
             when (diaryListState) {
-                is DiaryListState.Idle -> {}
+                is DiaryListState.Idle -> {
+
+                }
+
                 is DiaryListState.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .padding(innerPadding)
-                                .wrapContentSize(Alignment.Center),
-                            color = ClodyTheme.colors.mainYellow
-                        )
-                    }
+                    LoadingScreen()
                 }
 
                 is DiaryListState.Success -> {
                     MonthlyDiaryList(
                         paddingValues = innerPadding,
                         onClickReplyDiary = onClickReplyDiary,
-                        diaries = (diaryListState as DiaryListState.Success).data.diaries,
+                        diaries = diaryListState.data.diaries,
                         diaryListViewModel = diaryListViewModel
                     )
                 }
 
                 is DiaryListState.Failure -> {
-                    showToast(message = "${(diaryListState as DiaryListState.Failure).errorMessage}")
+                    FailureScreen()
+                }
+            }
+
+            when (deleteDiaryResult) {
+                is DeleteDiaryListState.Idle -> {
+
+                }
+
+                is DeleteDiaryListState.Loading -> {
+                    LoadingScreen()
+                }
+
+                is DeleteDiaryListState.Success -> {
+                    LaunchedEffect(Unit) {
+                        diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
+                    }
+                }
+
+                is DeleteDiaryListState.Failure -> {
+                    FailureScreen()
                 }
             }
         }
     )
 
-    if (showYearMonthPickerState) {
-        ClodyPopupBottomSheet(onDismissRequest = { showYearMonthPickerState = false }) {
+    if (showYearMonthPicker) {
+        ClodyPopupBottomSheet(onDismissRequest = { updateYearMonthPicker(false) }) {
             YearMonthPicker(
-                onDismissRequest = { showYearMonthPickerState = false },
+                onDismissRequest = { updateYearMonthPicker(false) },
                 selectedYear = selectedYearInDiaryList,
                 selectedMonth = selectedMonthInDiaryList,
-                onYearMonthSelected = onYearMonthSelected
+                onYearMonthSelected = updateYearAndMonth
             )
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -146,7 +146,9 @@ fun DiaryListScreen(
     )
 
     if (yearMonthPickerState) {
-        ClodyPopupBottomSheet(onDismissRequest = dismissYearMonthPicker) {
+        ClodyPopupBottomSheet(
+            onDismissRequest = dismissYearMonthPicker
+        ) {
             YearMonthPicker(
                 onDismissRequest = dismissYearMonthPicker,
                 selectedYear = selectedYearInDiaryList,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -165,10 +165,10 @@ fun DiaryListScreen(
 
     if (diaryDeleteDialogState) {
         ClodyDialog(
-            titleMassage = stringResource(R.string.delete_diary_dialog_title),
-            descriptionMassage = stringResource(R.string.delete_diary_dialog_description),
-            confirmOption = stringResource(R.string.delete_diary_dialog_confirm_option),
-            dismissOption = stringResource(R.string.delete_diary_dialog_dismiss_option),
+            titleMassage = stringResource(R.string.diary_delete_dialog_title),
+            descriptionMassage = stringResource(R.string.diary_delete_dialog_description),
+            confirmOption = stringResource(R.string.diary_delete_dialog_confirm_option),
+            dismissOption = stringResource(R.string.diary_delete_dialog_dismiss_option),
             confirmAction = {
                 onClickDiaryDelete()
                 dismissDiaryDeleteDialog()

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -29,7 +29,7 @@ fun DiaryListRoute(
     var selectedYearInDiaryList by remember { mutableIntStateOf(selectedYearFromHome) }
     var selectedMonthInDiaryList by remember { mutableIntStateOf(selectedMonthFromHome) }
     val diaryListState by diaryListViewModel.diaryListState.collectAsState()
-    val deleteDiaryResult by diaryListViewModel.deleteDiaryResult.collectAsState()
+    val deleteDiaryState by diaryListViewModel.deleteDiaryState.collectAsState()
     var showYearMonthPicker by remember { mutableStateOf(false) }
 
     LaunchedEffect(selectedYearInDiaryList, selectedMonthInDiaryList) {
@@ -45,7 +45,7 @@ fun DiaryListRoute(
             selectedMonthInDiaryList = newMonth
         },
         diaryListState = diaryListState,
-        deleteDiaryResult = deleteDiaryResult,
+        deleteDiaryState = deleteDiaryState,
         showYearMonthPicker = showYearMonthPicker,
         updateYearMonthPicker = { state -> showYearMonthPicker = state },
         onClickCalendar = { selectedYearFromDiaryList, selectedMonthFromDiaryList -> navigator.navigateHome(selectedYearFromDiaryList, selectedMonthFromDiaryList) },
@@ -60,7 +60,7 @@ fun DiaryListScreen(
     selectedMonthInDiaryList: Int,
     updateYearAndMonth: (Int, Int) -> Unit,
     diaryListState: DiaryListState,
-    deleteDiaryResult: DeleteDiaryListState,
+    deleteDiaryState: DeleteDiaryState,
     showYearMonthPicker: Boolean,
     updateYearMonthPicker: (Boolean) -> Unit,
     onClickCalendar: (Int, Int) -> Unit,
@@ -100,22 +100,22 @@ fun DiaryListScreen(
                 }
             }
 
-            when (deleteDiaryResult) {
-                is DeleteDiaryListState.Idle -> {
+            when (deleteDiaryState) {
+                is DeleteDiaryState.Idle -> {
 
                 }
 
-                is DeleteDiaryListState.Loading -> {
+                is DeleteDiaryState.Loading -> {
                     LoadingScreen()
                 }
 
-                is DeleteDiaryListState.Success -> {
+                is DeleteDiaryState.Success -> {
                     LaunchedEffect(Unit) {
                         diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
                     }
                 }
 
-                is DeleteDiaryListState.Failure -> {
+                is DeleteDiaryState.Failure -> {
                     FailureScreen()
                 }
             }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListState.kt
@@ -2,7 +2,6 @@ package com.sopt.clody.presentation.ui.diarylist.screen
 
 import com.sopt.clody.data.remote.dto.response.ResponseMonthlyDiaryDto
 
-
 sealed class DiaryListState {
     data object Idle : DiaryListState()
     data object Loading : DiaryListState()

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
@@ -20,17 +20,8 @@ class DiaryListViewModel @Inject constructor(
     private val _diaryListState = MutableStateFlow<DiaryListState>(DiaryListState.Idle)
     val diaryListState: StateFlow<DiaryListState> = _diaryListState
 
-    private val _selectedDiaryYear = MutableStateFlow(0)
-    val selectedDiaryYear: StateFlow<Int> = _selectedDiaryYear
-
-    private val _selectedDiaryMonth = MutableStateFlow(0)
-    val selectedDiaryMonth: StateFlow<Int> = _selectedDiaryMonth
-
-    private val _selectedDiaryDay = MutableStateFlow(0)
-    val selectedDiaryDay: StateFlow<Int> = _selectedDiaryDay
-
-    private val _selectedDiaryDayOfWeek = MutableStateFlow("")
-    val selectedDiaryDayOfWeek: StateFlow<String> = _selectedDiaryDayOfWeek
+    private val _selectedDiaryDate = MutableStateFlow(DiaryDate())
+    val selectedDiaryDate: StateFlow<DiaryDate> = _selectedDiaryDate
 
     private val _diaryDeleteState = MutableStateFlow<DiaryDeleteState>(DiaryDeleteState.Idle)
     val diaryDeleteState: StateFlow<DiaryDeleteState> get() = _diaryDeleteState
@@ -48,10 +39,11 @@ class DiaryListViewModel @Inject constructor(
 
     fun setSelectedDiaryDate(selectedDiaryDate: String) {
         val diaryDate = selectedDiaryDate.split("-")
-        _selectedDiaryYear.value = diaryDate[0].toInt()
-        _selectedDiaryMonth.value = diaryDate[1].toInt()
-        _selectedDiaryDay.value = diaryDate[2].toInt()
-        _selectedDiaryDayOfWeek.value = getDayOfWeek(_selectedDiaryYear.value, _selectedDiaryMonth.value, _selectedDiaryDay.value)
+        val year = diaryDate[0].toInt()
+        val month = diaryDate[1].toInt()
+        val day = diaryDate[2].toInt()
+        val dayOfWeek = getDayOfWeek(year, month, day)
+        _selectedDiaryDate.value = DiaryDate(year, month, day, dayOfWeek)
     }
 
     fun deleteDailyDiary(year: Int, month: Int, day: Int) {
@@ -68,4 +60,11 @@ class DiaryListViewModel @Inject constructor(
             )
         }
     }
+
+    data class DiaryDate(
+        val year: Int = 0,
+        val month: Int = 0,
+        val day: Int = 0,
+        val dayOfWeek: String = ""
+    )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
@@ -4,13 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sopt.clody.data.repository.DailyDiaryListRepository
 import com.sopt.clody.data.repository.DiaryListRepository
-import com.sopt.clody.presentation.ui.home.screen.DeleteDiaryState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
 
 @HiltViewModel
 class DiaryListViewModel @Inject constructor(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
@@ -19,8 +19,8 @@ class DiaryListViewModel @Inject constructor(
     private val _diaryListState = MutableStateFlow<DiaryListState>(DiaryListState.Idle)
     val diaryListState: StateFlow<DiaryListState> = _diaryListState
 
-    private val _deleteDiaryResult = MutableStateFlow<DeleteDiaryListState>(DeleteDiaryListState.Idle)
-    val deleteDiaryResult: StateFlow<DeleteDiaryListState> get() = _deleteDiaryResult
+    private val _deleteDiaryState = MutableStateFlow<DeleteDiaryState>(DeleteDiaryState.Idle)
+    val deleteDiaryState: StateFlow<DeleteDiaryState> get() = _deleteDiaryState
 
     fun fetchMonthlyDiary(year: Int, month: Int) {
         _diaryListState.value = DiaryListState.Loading
@@ -35,14 +35,14 @@ class DiaryListViewModel @Inject constructor(
 
     fun deleteDailyDiary(year: Int, month: Int, day: Int) {
         viewModelScope.launch {
-            _deleteDiaryResult.value = DeleteDiaryListState.Loading
+            _deleteDiaryState.value = DeleteDiaryState.Loading
             val result = dailyDiaryListRepository.deleteDailyDiary(year, month, day)
-            _deleteDiaryResult.value = result.fold(
+            _deleteDiaryState.value = result.fold(
                 onSuccess = {
-                    DeleteDiaryListState.Success
+                    DeleteDiaryState.Success
                 },
                 onFailure = {
-                    DeleteDiaryListState.Failure(it.message ?: "Unknown error")
+                    DeleteDiaryState.Failure(it.message ?: "Unknown error")
                 }
             )
         }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
@@ -19,8 +19,17 @@ class DiaryListViewModel @Inject constructor(
     private val _diaryListState = MutableStateFlow<DiaryListState>(DiaryListState.Idle)
     val diaryListState: StateFlow<DiaryListState> = _diaryListState
 
-    private val _deleteDiaryState = MutableStateFlow<DeleteDiaryState>(DeleteDiaryState.Idle)
-    val deleteDiaryState: StateFlow<DeleteDiaryState> get() = _deleteDiaryState
+    private val _selectedDiaryYear = MutableStateFlow(0)
+    val selectedDiaryYear: StateFlow<Int> = _selectedDiaryYear
+
+    private val _selectedDiaryMonth = MutableStateFlow(0)
+    val selectedDiaryMonth: StateFlow<Int> = _selectedDiaryMonth
+
+    private val _selectedDiaryDay = MutableStateFlow(0)
+    val selectedDiaryDay: StateFlow<Int> = _selectedDiaryDay
+
+    private val _diaryDeleteState = MutableStateFlow<DiaryDeleteState>(DiaryDeleteState.Idle)
+    val diaryDeleteState: StateFlow<DiaryDeleteState> get() = _diaryDeleteState
 
     fun fetchMonthlyDiary(year: Int, month: Int) {
         _diaryListState.value = DiaryListState.Loading
@@ -33,16 +42,22 @@ class DiaryListViewModel @Inject constructor(
         }
     }
 
+    fun setSelectedDiaryDate(selectedDiaryYear: Int, selectedDiaryMonth: Int, selectedDiaryDay: Int) {
+        _selectedDiaryYear.value = selectedDiaryYear
+        _selectedDiaryMonth.value = selectedDiaryMonth
+        _selectedDiaryDay.value = selectedDiaryDay
+    }
+
     fun deleteDailyDiary(year: Int, month: Int, day: Int) {
         viewModelScope.launch {
-            _deleteDiaryState.value = DeleteDiaryState.Loading
+            _diaryDeleteState.value = DiaryDeleteState.Loading
             val result = dailyDiaryListRepository.deleteDailyDiary(year, month, day)
-            _deleteDiaryState.value = result.fold(
+            _diaryDeleteState.value = result.fold(
                 onSuccess = {
-                    DeleteDiaryState.Success
+                    DiaryDeleteState.Success
                 },
                 onFailure = {
-                    DeleteDiaryState.Failure(it.message ?: "Unknown error")
+                    DiaryDeleteState.Failure(it.message ?: "Unknown error")
                 }
             )
         }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sopt.clody.data.repository.DailyDiaryListRepository
 import com.sopt.clody.data.repository.DiaryListRepository
+import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -28,6 +29,9 @@ class DiaryListViewModel @Inject constructor(
     private val _selectedDiaryDay = MutableStateFlow(0)
     val selectedDiaryDay: StateFlow<Int> = _selectedDiaryDay
 
+    private val _selectedDiaryDayOfWeek = MutableStateFlow("")
+    val selectedDiaryDayOfWeek: StateFlow<String> = _selectedDiaryDayOfWeek
+
     private val _diaryDeleteState = MutableStateFlow<DiaryDeleteState>(DiaryDeleteState.Idle)
     val diaryDeleteState: StateFlow<DiaryDeleteState> get() = _diaryDeleteState
 
@@ -42,10 +46,12 @@ class DiaryListViewModel @Inject constructor(
         }
     }
 
-    fun setSelectedDiaryDate(selectedDiaryYear: Int, selectedDiaryMonth: Int, selectedDiaryDay: Int) {
-        _selectedDiaryYear.value = selectedDiaryYear
-        _selectedDiaryMonth.value = selectedDiaryMonth
-        _selectedDiaryDay.value = selectedDiaryDay
+    fun setSelectedDiaryDate(selectedDiaryDate: String) {
+        val diaryDate = selectedDiaryDate.split("-")
+        _selectedDiaryYear.value = diaryDate[0].toInt()
+        _selectedDiaryMonth.value = diaryDate[1].toInt()
+        _selectedDiaryDay.value = diaryDate[2].toInt()
+        _selectedDiaryDayOfWeek.value = getDayOfWeek(_selectedDiaryYear.value, _selectedDiaryMonth.value, _selectedDiaryDay.value)
     }
 
     fun deleteDailyDiary(year: Int, month: Int, day: Int) {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -25,10 +25,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
-import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.component.bottomsheet.DiaryDeleteSheet
 import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
 import com.sopt.clody.presentation.ui.component.popup.ClodyPopupBottomSheet
+import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.home.calendar.ClodyCalendar
 import com.sopt.clody.presentation.ui.home.component.CloverCount
 import com.sopt.clody.presentation.ui.home.component.DiaryStateButton
@@ -111,7 +111,7 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             HomeTopAppBar(
-                onClickDiaryList = { onClickDiaryList(selectedYearInCalendar,selectedMonthInCalendar) },
+                onClickDiaryList = { onClickDiaryList(selectedYearInCalendar, selectedMonthInCalendar) },
                 onClickSetting = onClickSetting,
                 onShowYearMonthPickerStateChange = { newState -> showYearMonthPickerState = newState },
                 selectedYear = selectedYearInCalendar,
@@ -183,7 +183,7 @@ fun HomeScreen(
     if (showDiaryDeleteState) {
         DiaryDeleteSheet(
             onDismiss = { showDiaryDeleteState = false },
-            onShowDiaryDeleteDialogStateChange = { newState -> showDiaryDeleteDialog = newState }
+            showDiaryDeleteDialog = { showDiaryDeleteDialog = true }
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,10 +42,10 @@
     <string name="diarylist_check_reply">답장 확인</string>
 
     <!-- 일기 삭제 다이얼로그-->
-    <string name="delete_diary_dialog_title">정말 일기를 삭제할까요?</string>
-    <string name="delete_diary_dialog_description">아직 답장이 오지 않았거나 삭제하고\n다시 작성한 일기는 답장을 받을 수 없어요.</string>
-    <string name="delete_diary_dialog_confirm_option">삭제할래요</string>
-    <string name="delete_diary_dialog_dismiss_option">아니요</string>
+    <string name="diary_delete_dialog_title">정말 일기를 삭제할까요?</string>
+    <string name="diary_delete_dialog_description">아직 답장이 오지 않았거나 삭제하고\n다시 작성한 일기는 답장을 받을 수 없어요.</string>
+    <string name="diary_delete_dialog_confirm_option">삭제할래요</string>
+    <string name="diary_delete_dialog_dismiss_option">아니요</string>
 
     <!-- 일기 모아보기 -->
     <string name="diarylist_selected_year_month">%1$s년 %2$s월</string>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #132 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 일기모아보기 페이지 Route, Screen 개선

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 개선하면서 가장 신경 쓴 부분은 
  **"데이터 관련은 ViewModel과 Route로, UI 관련은 Screen으로"** 딱 이 책임분리를 가져가려고 노력했습니다. 
  Screen 단에서는 showDiaryDeleteBottomSheet와 같은 함수가 어떤 동작을 하는지 모르며, 
  오로지 트리거(?)의 역할만 하고 있습니다. Screen의 param을 보면 함수들이 웬만하면 () -> Unit 으로 전달되게 했습니다.
  그렇게 Screen과 Component에서는 어떤 변수도 존재하지 않게 하려고 했습니다.
- 다만 `1. 일일 일기가 담긴 카드를 구현하고`, `2. 그에 대한 답장 확인을 위해 네비게이션에 날짜를 전달하거나,`
 ` 3. 일기 삭제를 눌렀을때 해당 날짜 정보를 전달하려는 과정`에서 데이터 반영이 제대로 되지 않는 문제가 생겼습니다.
  최대한 해결하려 했으나.. 시간을 너무 많이 잡아먹어서 이 부분은 일단 구현에 중점을 두고 PR을 올렸고
  구현해야할 기능들이 다 되고 나면, 추후 수정해보도록 하겠습니다 ㅠㅠ..

## 📸 스크린샷/동영상