### PR TITLE
[FEAT/#144] 닉네임 변경 완료 시 토스트 메시지 노출

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/toast/ClodyToastMessage.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/toast/ClodyToastMessage.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -40,9 +41,9 @@ fun ClodyToastMessage(
 
     Box(
         modifier = modifier
-            .height(42.dp)
-            .background(color = backgroundColor, shape = RoundedCornerShape(26.5.dp))
-            .padding(horizontal = 14.5.dp, vertical = 11.dp)
+            .wrapContentHeight()
+            .background(color = backgroundColor, shape = RoundedCornerShape(28.dp))
+            .padding(horizontal = 22.dp, vertical = 16.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Image(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/AccountManagementScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/AccountManagementScreen.kt
@@ -1,8 +1,10 @@
 package com.sopt.clody.presentation.ui.setting.screen
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -11,13 +13,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.clody.R
 import com.sopt.clody.presentation.ui.component.FailureScreen
 import com.sopt.clody.presentation.ui.component.LoadingScreen
 import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
+import com.sopt.clody.presentation.ui.component.toast.ClodyToastMessage
 import com.sopt.clody.presentation.ui.setting.component.AccountManagementLogoutOption
 import com.sopt.clody.presentation.ui.setting.component.AccountManagementNicknameOption
 import com.sopt.clody.presentation.ui.setting.component.AccountManagementRevokeOption
@@ -52,6 +57,7 @@ fun AccountManagementRoute(
     AccountManagementScreen(
         accountManagementViewModel = accountManagementViewModel,
         userInfoState = userInfoState,
+        userNicknameState = userNicknameState,
         showNicknameChangeBottomSheet = showNicknameChangeBottomSheet,
         updateNicknameChangeBottomSheet = { state -> showNicknameChangeBottomSheet = state },
         showLogoutDialog = showLogoutDialog,
@@ -66,6 +72,7 @@ fun AccountManagementRoute(
 fun AccountManagementScreen(
     accountManagementViewModel: AccountManagementViewModel,
     userInfoState: UserInfoState,
+    userNicknameState: UserNicknameState,
     showNicknameChangeBottomSheet: Boolean,
     updateNicknameChangeBottomSheet: (Boolean) -> Unit,
     showLogoutDialog: Boolean,
@@ -126,6 +133,24 @@ fun AccountManagementScreen(
         )
     }
 
+    if(userNicknameState is UserNicknameState.Success) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(20.dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            ClodyToastMessage(
+                message = stringResource(R.string.account_management_nickname_change_toast),
+                iconResId = R.drawable.ic_toast_check_on_18,
+                backgroundColor = ClodyTheme.colors.gray04,
+                contentColor = ClodyTheme.colors.white,
+                durationMillis = 3000,
+                onDismiss = { accountManagementViewModel.resetUserNicknameState() },
+            )
+        }
+    }
+
     if (showLogoutDialog) {
         LogoutDialog(
             titleMassage = stringResource(R.string.account_management_logout_dialog_title),
@@ -146,7 +171,7 @@ fun AccountManagementScreen(
             confirmAction = { accountManagementViewModel.revokeAccount() },
             confirmButtonColor = ClodyTheme.colors.red,
             confirmButtonTextColor = ClodyTheme.colors.white,
-            onDismiss = { updateRevokeDialog(false) },
+            onDismiss = { updateRevokeDialog(false) }
         )
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/AccountManagementViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/AccountManagementViewModel.kt
@@ -56,6 +56,10 @@ class AccountManagementViewModel @Inject constructor(
         }
     }
 
+    fun resetUserNicknameState() {
+        _userNicknameState.value = UserNicknameState.Idle
+    }
+
     fun logOutAccount() {
         viewModelScope.launch {
             tokenDataStore.clearInfo()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="account_management_nickname_change_title">닉네임 변경</string>
     <string name="account_management_nickname_change_notice">특수문자, 띄어쓰기 없이 작성해주세요</string>
     <string name="account_management_nickname_change_confirm">변경하기</string>
+    <string name="account_management_nickname_change_toast">변경을 완료했어요.</string>
     <string name="account_management_logout_button">로그아웃</string>
     <string name="account_management_logout_dialog_title">로그아웃 하시겠어요?</string>
     <string name="account_management_logout_dialog_description">기다릴게요, 다음에 다시 만나요!</string>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #144 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 닉네임 변경 완료 시 토스트 메시지 노출

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- ClodyToastMessage 공통 컴포넌트에서 하드코딩 되어있는 modifier를 좀 수정했습니다.
- 닉네임 변경 상태 관찰하다가 성공하면 토스트 메시지 노출되도록 설계했고, dismiss로 Idle 상태로 돌아가도록 했습니다.

## 📸 스크린샷/동영상

https://github.com/user-attachments/assets/775e1fd1-8aad-41d9-bd2b-bd89ba985b4f

