### PR TITLE
[FEAT/#141] 일기 모아보기 페이지 빈 리스트 대응화면 추가

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/EmptyDiaryList.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/EmptyDiaryList.kt
@@ -1,0 +1,27 @@
+package com.sopt.clody.presentation.ui.diarylist.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.sopt.clody.R
+import com.sopt.clody.ui.theme.ClodyTheme
+
+@Composable
+fun EmptyDiaryList() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ){
+        Text(
+            text= stringResource(R.string.diary_list_empty_diary_list),
+            color = ClodyTheme.colors.gray06,
+            textAlign = TextAlign.Center,
+            style = ClodyTheme.typography.body2SemiBold
+        )
+    }
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -1,6 +1,9 @@
 package com.sopt.clody.presentation.ui.diarylist.screen
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -9,6 +12,8 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.clody.R
@@ -19,6 +24,7 @@ import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
 import com.sopt.clody.presentation.ui.component.popup.ClodyPopupBottomSheet
 import com.sopt.clody.presentation.ui.component.timepicker.YearMonthPicker
 import com.sopt.clody.presentation.ui.diarylist.component.DiaryListTopAppBar
+import com.sopt.clody.presentation.ui.diarylist.component.EmptyDiaryList
 import com.sopt.clody.presentation.ui.diarylist.component.MonthlyDiaryList
 import com.sopt.clody.presentation.ui.diarylist.navigation.DiaryListNavigator
 import com.sopt.clody.ui.theme.ClodyTheme
@@ -109,13 +115,16 @@ fun DiaryListScreen(
                 }
 
                 is DiaryListState.Success -> {
-                    MonthlyDiaryList(
-                        paddingValues = innerPadding,
-                        diaryListViewModel = diaryListViewModel,
-                        diaries = diaryListState.data.diaries,
-                        showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet,
-                        onClickReplyDiary = onClickReplyDiary
-                    )
+                    if (diaryListState.data.diaries.isEmpty()) EmptyDiaryList()
+                    else {
+                        MonthlyDiaryList(
+                            paddingValues = innerPadding,
+                            diaryListViewModel = diaryListViewModel,
+                            diaries = diaryListState.data.diaries,
+                            showDiaryDeleteBottomSheet = showDiaryDeleteBottomSheet,
+                            onClickReplyDiary = onClickReplyDiary
+                        )
+                    }
                 }
 
                 is DiaryListState.Failure -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
 
     <!-- 일기 모아보기 -->
     <string name="diarylist_selected_year_month">%1$s년 %2$s월</string>
+    <string name="diary_list_empty_diary_list">작성된 감사일기가 없어요</string>
     <string name="diarylist_daily_diary_day">%1$s일</string>
     <string name="diarylist_daily_diary_day_of_week">/%1$s</string>
 


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #141 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 해당 월에 작성한 일기가 없을 경우 대응화면 적용

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 대응화면 파일이름을 DiaryListEmptyScreen 으로 하려했으나, 화면 전체가 아닌 어떻게 보면 Scaffold의 content 컴포넌트인데 Screen으로 이름 짓는건 이상할 수도 있겠다 생각했습니다. 그래서 같은 역할을 하는 MonthlyDiaryList와 이름을 비슷하게 가자싶어서 EmptyDiaryList로 이름 짓게 되었습니다! 

## 📸 스크린샷/동영상

https://github.com/user-attachments/assets/95b1a4d7-6965-4f55-a6ba-811b13443af0

 
