### PR TITLE
[FEAT/#153] 일기 모아보기 페이지 답장확인 버튼 분기처리

### DIFF
--- a/app/src/main/java/com/sopt/clody/data/remote/dto/response/ResponseMonthlyDiaryDto.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/dto/response/ResponseMonthlyDiaryDto.kt
@@ -13,7 +13,8 @@ data class ResponseMonthlyDiaryDto(
         @SerialName("diaryCount") val diaryCount: Int,
         @SerialName("replyStatus") val replyStatus: String,
         @SerialName("date") val date: String,
-        @SerialName("diary") val diary: List<DailyDiaryContent>
+        @SerialName("diary") val diary: List<DailyDiaryContent>,
+        @SerialName("isDeleted") val isDeleted: Boolean
     ) {
         @Serializable
         data class DailyDiaryContent(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -129,7 +129,7 @@ fun ReplyDiaryButton(
             modifier = Modifier
                 .height(33.dp)
                 .padding(horizontal = 3.dp, vertical = 3.dp),
-            enabled = dailyDiary.replyStatus != "UNREADY",
+            enabled = !(dailyDiary.isDeleted),
             colors = ButtonDefaults.buttonColors(
                 containerColor = ClodyTheme.colors.lightBlue,
                 contentColor = ClodyTheme.colors.blue,


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #153  

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 일기 모아보기 페이지 답장 확인 버튼 분기 처리

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 이제 일기를 삭제하고 재작성 하는 날은 isDeleted 값이 true로 오게 되고, 그러면 답장확인 버튼이 비활성화 됩니다. 그리고 답장 상태에 따라 "READY_NOT_READ" 라면 빨간색 n 버튼이 붙게 됩니다!
- 컨플릭트 해결하다가 중괄호 오류 난 부분은 연진이누나가 머지하면 풀 땡기고 머지하도록 하겠슴다..

## 📸 스크린샷/동영상
![clody#153replybutton](https://github.com/user-attachments/assets/5b26ab22-a65f-4e83-8955-ea4cd75d178e)
