### PR TITLE
[FIX/#158] 캘린더 및 일기 API 중복 호출 제거

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/ClodyCalendar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/ClodyCalendar.kt
@@ -62,15 +62,26 @@ fun ClodyCalendar(
         HorizontalDivider()
 
         when (val state = dailyDiariesUiState) {
-            is DailyDiariesState.Loading -> LoadingScreen()
-            is DailyDiariesState.Error -> FailureScreen()
-            is DailyDiariesState.Success -> DailyDiaryListItem(
-                date = selectedDate,
-                dayOfWeek = initialDayOfWeek,
-                dailyDiaries = state.data.diaries,
-                onShowDiaryDeleteStateChange = onShowDiaryDeleteStateChange
-            )
-            else -> Unit
+            is DailyDiariesState.Idle -> {
+
+            }
+
+            is DailyDiariesState.Loading -> {
+                LoadingScreen()
+            }
+
+            is DailyDiariesState.Success -> {
+                DailyDiaryListItem(
+                    date = selectedDate,
+                    dayOfWeek = initialDayOfWeek,
+                    dailyDiaries = state.data.diaries,
+                    onShowDiaryDeleteStateChange = onShowDiaryDeleteStateChange
+                )
+            }
+
+            is DailyDiariesState.Error -> {
+                FailureScreen()
+            }
         }
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/ClodyCalendar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/ClodyCalendar.kt
@@ -1,25 +1,14 @@
 package com.sopt.clody.presentation.ui.home.calendar
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
@@ -31,7 +20,6 @@ import com.sopt.clody.presentation.ui.home.calendar.component.HorizontalDivider
 import com.sopt.clody.presentation.ui.home.calendar.component.MonthlyItem
 import com.sopt.clody.presentation.ui.home.screen.DailyDiariesState
 import com.sopt.clody.presentation.ui.home.screen.HomeViewModel
-import com.sopt.clody.ui.theme.ClodyTheme
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -52,7 +40,7 @@ fun ClodyCalendar(
     }
     val initialDayOfWeek = selectedDate.dayOfWeek
 
-    val dailyDiariesUiState by homeViewModel.dailyDiariesUiState.collectAsStateWithLifecycle()
+    val dailyDiariesUiState by homeViewModel.dailyDiariesState.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/HorizontalDivider.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/HorizontalDivider.kt
@@ -1,0 +1,26 @@
+package com.sopt.clody.presentation.ui.home.calendar.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.sopt.clody.ui.theme.ClodyTheme
+
+@Composable
+fun HorizontalDivider(
+    color: Color = ClodyTheme.colors.gray08,
+    thickness: Dp = 6.dp,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(thickness)
+            .background(color)
+    )
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -111,18 +111,7 @@ fun HomeScreen(
                 }
 
                 is CalendarState.Loading -> {
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                    }
-                }
-
-                is CalendarState.Error -> {
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        Text(
-                            text = "Failed to load calendar data: ${state.message}",
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
+                    LoadingScreen()
                 }
 
                 is CalendarState.Success -> {
@@ -139,6 +128,10 @@ fun HomeScreen(
                         },
                         modifier = Modifier.padding(innerPadding)
                     )
+                }
+
+                is CalendarState.Error -> {
+                    FailureScreen()
                 }
             }
 

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -3,22 +3,17 @@ package com.sopt.clody.presentation.ui.home.screen
 import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -115,7 +110,7 @@ fun HomeScreen(
                 }
 
                 is CalendarState.Success -> {
-                    ScrollableCalendarUI(
+                    ScrollableCalendar(
                         selectedYear = selectedDiaryDate.year,
                         selectedMonth = selectedDiaryDate.month,
                         cloverCount = state.data.totalCloverCount,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/ScrollableCalendar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/ScrollableCalendar.kt
@@ -17,7 +17,7 @@ import com.sopt.clody.ui.theme.ClodyTheme
 import java.time.LocalDate
 
 @Composable
-fun ScrollableCalendarUI(
+fun ScrollableCalendar(
     selectedYear: Int,
     selectedMonth: Int,
     cloverCount: Int,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/ScrollableCalendarUI.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/ScrollableCalendarUI.kt
@@ -1,0 +1,54 @@
+package com.sopt.clody.presentation.ui.home.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
+import com.sopt.clody.presentation.ui.home.calendar.ClodyCalendar
+import com.sopt.clody.presentation.ui.home.component.CloverCount
+import com.sopt.clody.ui.theme.ClodyTheme
+import java.time.LocalDate
+
+@Composable
+fun ScrollableCalendarUI(
+    selectedYear: Int,
+    selectedMonth: Int,
+    cloverCount: Int,
+    homeViewModel: HomeViewModel,
+    diaries: List<MonthlyCalendarResponseDto.Diary>,
+    onShowDiaryDeleteStateChange: (Boolean) -> Unit,
+    selectedDate: LocalDate,
+    onDiaryDataUpdated: (Int, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .background(ClodyTheme.colors.white)
+    ) {
+        CloverCount(cloverCount = cloverCount)
+        Spacer(modifier = Modifier.height(20.dp))
+        ClodyCalendar(
+            selectedYear = selectedYear,
+            selectedMonth = selectedMonth,
+            selectedDate = selectedDate,
+            onDateSelected = { date ->
+                homeViewModel.updateSelectedDate(date)
+            },
+            diaries = diaries,
+            homeViewModel = homeViewModel,
+            onDiaryDataUpdated = onDiaryDataUpdated,
+            onShowDiaryDeleteStateChange = onShowDiaryDeleteStateChange
+        )
+    }
+}


### PR DESCRIPTION
## 📌 개요
- closed #158 

## ✨ 작업 내용
- [ ] 홈 첫 진입시 캘린더 일기 api 중복호출 제거
- [ ] 홈 이동시 중복 호출 제거
- [ ] 데이 아이템 클릭시 중복 호출 제거
- [ ] 삭제 실시간 업데이트

## ✨ PR 포인트

## 📸 스크린샷/동영상
로그를 보여줄 수는 없으니... 필요하시면 카톡으로 보내드릴게염