### PR TITLE
[FEAT/#157] "설정 > 기타 옵션들" 네비게이션 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,30 +12,31 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CLODY"
-        tools:targetApi="31"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        tools:targetApi="31">
 
         <service
             android:name=".data.ClodyFirebaseMessagingService"
             android:exported="false">
             <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
 
 
         <activity
             android:name=".presentation.ui.main.MainActivity"
-            android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:label="@string/app_name"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.CLODY"
-            android:screenOrientation="portrait">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -44,14 +45,16 @@
 
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
-            android:launchMode="singleTask"
-            android:taskAffinity="${applicationId}.AuthCodeHandlerActivity"
             android:excludeFromRecents="true"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:taskAffinity="${applicationId}.AuthCodeHandlerActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
                     android:host="oauth"
                     android:scheme="${kakaoRedirectUri}" />

--- a/app/src/main/java/com/sopt/clody/presentation/ui/navigatior/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/navigatior/MainNavHost.kt
@@ -26,6 +26,7 @@ import com.sopt.clody.presentation.ui.setting.navigation.SettingNavigator
 import com.sopt.clody.presentation.ui.setting.navigation.accountManagementNavGraph
 import com.sopt.clody.presentation.ui.setting.navigation.notificationSettingNavGraph
 import com.sopt.clody.presentation.ui.setting.navigation.settingNavGraph
+import com.sopt.clody.presentation.ui.setting.navigation.webViewNavGraph
 import com.sopt.clody.presentation.ui.splash.SplashScreen
 import com.sopt.clody.presentation.ui.writediary.navigation.WriteDiaryNavigator
 import com.sopt.clody.presentation.ui.writediary.navigation.writeDiaryNavGraph
@@ -63,6 +64,7 @@ fun MainNavHost(
             settingNavGraph(settingNavigator)
             accountManagementNavGraph(settingNavigator)
             notificationSettingNavGraph(settingNavigator)
+            webViewNavGraph(settingNavigator)
             replyLoadingNavGraph(replyLoadingNavigator, replyDiaryNavigator)
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavGraph.kt
@@ -37,11 +37,11 @@ fun NavGraphBuilder.webViewNavGraph(
     navigator: SettingNavigator
 ) {
     composable(
-        route = "web_view/{encodeUrl}",
-        arguments = listOf(navArgument("encodeUrl") { type = NavType.StringType })
+        route = "web_view/{encodedUrl}",
+        arguments = listOf(navArgument("encodedUrl") { type = NavType.StringType })
     ) { backStackEntry ->
-        val encodeUrl = backStackEntry.arguments?.getString("encodeUrl")
-        encodeUrl?.let {
+        val encodedUrl = backStackEntry.arguments?.getString("encodedUrl")
+        encodedUrl?.let {
             WebViewRoute(navigator, it)
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavGraph.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavGraph.kt
@@ -1,10 +1,13 @@
 package com.sopt.clody.presentation.ui.setting.navigation
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.sopt.clody.presentation.ui.setting.screen.AccountManagementRoute
 import com.sopt.clody.presentation.ui.setting.screen.NotificationSettingRoute
 import com.sopt.clody.presentation.ui.setting.screen.SettingRoute
+import com.sopt.clody.presentation.ui.setting.screen.WebViewRoute
 
 fun NavGraphBuilder.settingNavGraph(
     navigator: SettingNavigator
@@ -27,5 +30,19 @@ fun NavGraphBuilder.notificationSettingNavGraph(
 ) {
     composable("notification_setting") {
         NotificationSettingRoute(navigator)
+    }
+}
+
+fun NavGraphBuilder.webViewNavGraph(
+    navigator: SettingNavigator
+) {
+    composable(
+        route = "web_view/{encodeUrl}",
+        arguments = listOf(navArgument("encodeUrl") { type = NavType.StringType })
+    ) { backStackEntry ->
+        val encodeUrl = backStackEntry.arguments?.getString("encodeUrl")
+        encodeUrl?.let {
+            WebViewRoute(navigator, it)
+        }
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavigator.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/navigation/SettingNavigator.kt
@@ -1,6 +1,7 @@
 package com.sopt.clody.presentation.ui.setting.navigation
 
 import androidx.navigation.NavHostController
+import java.net.URLEncoder
 
 class SettingNavigator(
     val navController: NavHostController
@@ -11,6 +12,11 @@ class SettingNavigator(
 
     fun navigateNotificationSetting() {
         navController.navigate("notification_setting")
+    }
+
+    fun navigateWebView(url: String) {
+        val encodedUrl = URLEncoder.encode(url, "UTF-8")
+        navController.navigate("web_view/$encodedUrl")
     }
 
     fun navigateBack() {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/SettingOptionUrls.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/SettingOptionUrls.kt
@@ -1,0 +1,8 @@
+package com.sopt.clody.presentation.ui.setting.screen
+
+object SettingOptionUrls {
+    const val ANNOUNCEMENT_URL = "https://phrygian-open-50e.notion.site/800f9d9e139740409ec1ebc6da0339e0?pvs=4"
+    const val INQUIRIES_SUGGESTIONS_URL = "https://forms.gle/WnLC7VwHacufVHiv7"
+    const val TERMS_OF_SERVICE_URL = "https://phrygian-open-50e.notion.site/4b8254c57c124f37afe3302ca7dd33c2?pvs=4"
+    const val PRIVACY_POLICY_URL = "https://phrygian-open-50e.notion.site/21cb8d6027404b2aa05741bcf67a4503?pvs=4"
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/SettingScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/SettingScreen.kt
@@ -1,5 +1,8 @@
 package com.sopt.clody.presentation.ui.setting.screen
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.clody.R
@@ -35,7 +39,8 @@ fun SettingRoute(
         versionInfo = versionInfo ?: stringResource(R.string.setting_version_info_failure),
         onClickBack = { navigator.navigateBack() },
         onClickAccountManagement = { navigator.navigateAccountManagement() },
-        onClickNotificationSetting = { navigator.navigateNotificationSetting() }
+        onClickNotificationSetting = { navigator.navigateNotificationSetting() },
+        onClickInquiriesSuggestions = { navigator.navigateWebView(SettingOptionUrls.INQUIRIES_SUGGESTIONS_URL) },
     )
 }
 
@@ -46,8 +51,10 @@ fun SettingScreen(
     onClickBack: () -> Unit,
     onClickAccountManagement: () -> Unit,
     onClickNotificationSetting: () -> Unit,
+    onClickInquiriesSuggestions: () -> Unit
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val context = LocalContext.current
 
     Scaffold(
         modifier = Modifier
@@ -64,14 +71,19 @@ fun SettingScreen(
             SettingSeparateLine()
 
             SettingOption(option = stringResource(R.string.setting_option_notification_setting), onClickNotificationSetting)
-            SettingOption(option = stringResource(R.string.setting_option_announcement), { /* TODO : 공지사항 이동 */ })
-            SettingOption(option = stringResource(R.string.setting_option_inquiries_suggestions), { /* TODO : 문의/제안하기 이동 */ })
+            SettingOption(option = stringResource(R.string.setting_option_announcement)) { onClickSettingOption(context, SettingOptionUrls.ANNOUNCEMENT_URL) }
+            SettingOption(option = stringResource(R.string.setting_option_inquiries_suggestions), onClickInquiriesSuggestions)
 
             SettingSeparateLine()
 
-            SettingOption(option = stringResource(R.string.setting_option_terms_of_service), { /* TODO : 서비스 이용 약관 이동 */ })
-            SettingOption(option = stringResource(R.string.setting_option_privacy_policy), { /* TODO : 개인정보 처리방침 이동 */ })
+            SettingOption(option = stringResource(R.string.setting_option_terms_of_service)) { onClickSettingOption(context, SettingOptionUrls.TERMS_OF_SERVICE_URL) }
+            SettingOption(option = stringResource(R.string.setting_option_privacy_policy)) { onClickSettingOption(context, SettingOptionUrls.PRIVACY_POLICY_URL) }
             SettingVersionInfo(versionInfo = versionInfo)
         }
     }
+}
+
+fun onClickSettingOption(context: Context, url: String) {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+    context.startActivity(intent)
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/WebViewScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/WebViewScreen.kt
@@ -1,0 +1,77 @@
+package com.sopt.clody.presentation.ui.setting.screen
+
+import android.annotation.SuppressLint
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.sopt.clody.presentation.ui.setting.navigation.SettingNavigator
+
+@Composable
+fun WebViewRoute(
+    navigator: SettingNavigator,
+    encodeUrl: String
+) {
+    WebViewScreen(
+        encodeUrl = encodeUrl,
+        onClickBack = { navigator.navigateBack() }
+    )
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun WebViewScreen(
+    encodeUrl: String,
+    onClickBack: () -> Unit
+) {
+    var webView: WebView? by remember { mutableStateOf(null) }
+    val canGoBack by remember { derivedStateOf { webView?.canGoBack() ?: false } }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        content = { innerPadding ->
+            AndroidView(
+                factory = { context ->
+                    WebView(context).apply {
+                        webViewClient = WebViewClient()
+                        settings.apply {
+                            javaScriptEnabled = true
+                            domStorageEnabled = true
+                            useWideViewPort = true
+                            loadWithOverviewMode = true
+                            allowFileAccess = true
+                            allowContentAccess = true
+                            javaScriptCanOpenWindowsAutomatically = true
+                            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                        }
+                        loadUrl(encodeUrl)
+                        webView = this
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            )
+        }
+    )
+
+    BackHandler(enabled = canGoBack) {
+        if (canGoBack) {
+            webView?.goBack()
+        } else {
+            onClickBack()
+        }
+    }
+}
+

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/WebViewScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/WebViewScreen.kt
@@ -21,10 +21,10 @@ import com.sopt.clody.presentation.ui.setting.navigation.SettingNavigator
 @Composable
 fun WebViewRoute(
     navigator: SettingNavigator,
-    encodeUrl: String
+    encodedUrl: String
 ) {
     WebViewScreen(
-        encodeUrl = encodeUrl,
+        encodedUrl = encodedUrl,
         onClickBack = { navigator.navigateBack() }
     )
 }
@@ -32,7 +32,7 @@ fun WebViewRoute(
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun WebViewScreen(
-    encodeUrl: String,
+    encodedUrl: String,
     onClickBack: () -> Unit
 ) {
     var webView: WebView? by remember { mutableStateOf(null) }
@@ -55,7 +55,7 @@ fun WebViewScreen(
                             javaScriptCanOpenWindowsAutomatically = true
                             mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
                         }
-                        loadUrl(encodeUrl)
+                        loadUrl(encodedUrl)
                         webView = this
                     }
                 },


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #157 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->

-  공지사항 네비게이션 연결
-  문의/제안하기 네비게이션 연결
-  서비스 이용 약관 네비게이션 연결
-  개인정보 처리방침 네비게이션 연결

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 문의/제안하기는 웹뷰로 연결하기 성공했습니다. 웹뷰의 경우 백핸들러 조정까지 완료했습니다
- 기타 노션 페이지로 연결해야하는 옵션들은 타이틀만 뜨고 내용이 뜨지 않는 이슈가 발생했는데, 아무래도 노션 보안정책과 관련이 있거나 노션에 로그인 문제가 있는거 같아 당장 해결하기에는 시간이 부족하다는 생각이 들어 일단 intent를 사용하는 방법으로 구현했습니다. 

## 📸 스크린샷/동영상

https://github.com/user-attachments/assets/9a2774d4-baac-41c2-b26c-ece953658fae

