### PR TITLE
[Fix/#161] 과거일기 로딩시간 계산 수정

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
@@ -38,7 +37,7 @@ import com.sopt.clody.presentation.ui.component.button.ClodyButton
 import com.sopt.clody.presentation.ui.replyloading.navigation.ReplyLoadingNavigator
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.delay
-import java.time.LocalTime
+import java.time.LocalDateTime
 
 @Composable
 fun ReplyLoadingRoute(
@@ -85,11 +84,10 @@ fun ReplyLoadingScreen(
 
     LaunchedEffect(replyLoadingState) {
         if (replyLoadingState is ReplyLoadingState.Success) {
-            val diaryTime = with(replyLoadingState as ReplyLoadingState.Success) {
-                (HH * 3600 + MM * 60 + SS).toLong()
-            }
-            val currentTime = LocalTime.now().toSecondOfDay().toLong()
-            val timeDiff = diaryTime - currentTime
+            val targetDateTime = (replyLoadingState as ReplyLoadingState.Success).targetDateTime
+            val currentDateTime = LocalDateTime.now()
+
+            val timeDiff = java.time.Duration.between(currentDateTime, targetDateTime).seconds
             remainingTime = if (timeDiff > 0) timeDiff else 0
             isComplete = remainingTime <= 0
         }
@@ -212,14 +210,4 @@ fun ReplyLoadingScreen(
                 .padding(horizontal = 12.dp)
         )
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewReplyLoadingScreen() {
-    ReplyLoadingScreen(
-        onCompleteClick = { /*TODO*/ },
-        onBackClick = { /*TODO*/ },
-        replyLoadingState = ReplyLoadingState.Success(1, 2, 3)
-    )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingState.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingState.kt
@@ -1,11 +1,10 @@
 package com.sopt.clody.presentation.ui.replyloading.screen
 
-import com.sopt.clody.presentation.ui.replydiary.ReplyDiaryState
+import java.time.LocalDateTime
 
 sealed class ReplyLoadingState {
     data object Idle : ReplyLoadingState()
     data object Loading : ReplyLoadingState()
-    data class Success(val HH: Int, val MM: Int, val SS: Int) : ReplyLoadingState()
-
+    data class Success(val targetDateTime: LocalDateTime) : ReplyLoadingState()
     data class Failure(val error: String) : ReplyLoadingState()
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,15 +24,12 @@ class ReplyLoadingViewModel @Inject constructor(
             val result = diaryTimeRepository.getDiaryTime(year, month, date)
             _replyLoadingState.value = result.fold(
                 onSuccess = { data ->
-                    val newHH = data.HH
-                    val newMM = data.MM + 1
-                    val finalMM = newMM % 60
-                    val finalHH = (newHH + newMM / 60) % 24
-                    ReplyLoadingState.Success(
-                        HH = finalHH,
-                        MM = finalMM,
-                        SS = data.SS
-                    )
+                    val targetDateTime = LocalDateTime.of(
+                        year, month, date,
+                        data.HH, data.MM, data.SS
+                    ).plusMinutes(1)
+
+                    ReplyLoadingState.Success(targetDateTime)
                 },
                 onFailure = { ReplyLoadingState.Failure(it.message ?: "Unknown error") }
             )


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #161 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 과거 일기 시간계산 수정

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 기존 코드에서 LocalTime.now()를 사용하여 현재 시간을 기준으로 남은 시간을 계산했는데. 현재 날짜를 기준으로 시간을 계산해서 오늘이 아닌 다른 날짜에 작성된 일기의 남은 시간이 잘못 계산되는 문제가 발견되었습니다. 그래서 LocalDateTime을 사용하여 targetDateTime을 계산하는 방법으로 수정했더니 잘됩니다.

## 📸 스크린샷/동영상
