### PR TITLE
[UI/#172] 리플 효과 개선

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/component/textfield/NickNameTextField.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/component/textfield/NickNameTextField.kt
@@ -3,6 +3,7 @@ package com.sopt.clody.presentation.ui.auth.component.textfield
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
@@ -78,7 +80,12 @@ fun NickNameTextField(
                         }
                         Box(
                             modifier = Modifier
-                                .clickable { onRemove() },
+                                .clickable(
+                                    onClick = onRemove,
+                                    indication = null,
+                                    interactionSource = remember { MutableInteractionSource() }
+                                )
+                            ,
                             contentAlignment = Alignment.Center
                         ) {
                             Image(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/auth/timereminder/TimeReminderScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/auth/timereminder/TimeReminderScreen.kt
@@ -6,8 +6,9 @@ import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -178,24 +179,24 @@ fun TimeReminderScreen(
                 }
             )
 
-            TextButton(
-                onClick = { onStartClick() },
+            Text(
+                text = stringResource(id = R.string.time_reminder_next_setting_button),
                 modifier = Modifier
                     .constrainAs(nextSettingButton) {
-                        top.linkTo(completeButton.bottom)
+                        top.linkTo(completeButton.bottom, margin = 18.dp)
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
-                    },
-                contentPadding = PaddingValues(0.dp)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.time_reminder_next_setting_button),
-                    modifier = Modifier.wrapContentHeight(),
-                    style = ClodyTheme.typography.detail1Medium,
-                    color = ClodyTheme.colors.gray05,
-                    textDecoration = TextDecoration.Underline
-                )
-            }
+                    }
+                    .wrapContentHeight()
+                    .clickable(
+                        onClick = onStartClick,
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ),
+                style = ClodyTheme.typography.detail1Medium,
+                color = ClodyTheme.colors.gray05,
+                textDecoration = TextDecoration.Underline
+            )
 
             if (timeReminderState is TimeReminderState.Loading) {
                 CircularProgressIndicator(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/bottomsheet/DiaryDeleteSheet.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/bottomsheet/DiaryDeleteSheet.kt
@@ -3,6 +3,7 @@ package com.sopt.clody.presentation.ui.component.bottomsheet
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,11 +57,15 @@ fun DiaryDeleteBottomSheetItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .clickable {
-                    onDismiss()
-                    showDiaryDeleteDialog()
-                }
+                .clickable(
+                    onClick = {
+                        onDismiss()
+                        showDiaryDeleteDialog()
+                    },
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+
+                )
                 .padding(start = 24.dp)
         ) {
             Image(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DailyDiaryCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -125,7 +126,7 @@ fun ReplyDiaryButton(
         contentAlignment = Alignment.TopEnd
     ) {
         Button(
-            onClick = { onClickReplyDiary(year,month,day,dailyDiary.replyStatus) },
+            onClick = { onClickReplyDiary(year, month, day, dailyDiary.replyStatus) },
             modifier = Modifier
                 .height(33.dp)
                 .padding(horizontal = 3.dp, vertical = 3.dp),
@@ -167,11 +168,12 @@ fun DiaryDeleteButton(
         painter = painterResource(id = R.drawable.ic_listview_kebab_menu),
         contentDescription = "kebab menu",
         modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
             .clickable(
                 onClick = {
                     diaryListViewModel.setSelectedDiaryDate(dailyDiary.date)
                     showDiaryDeleteBottomSheet()
-                }
+                },
             )
     )
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DiaryListTopAppBar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/component/DiaryListTopAppBar.kt
@@ -3,6 +3,7 @@ package com.sopt.clody.presentation.ui.diarylist.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -40,7 +42,10 @@ fun DiaryListTopAppBar(
                 Row(
                     modifier = Modifier
                         .padding(start = 16.dp)
-                        .clickable(onClick = showYearMonthPicker),
+                        .clickable(
+                            onClick = showYearMonthPicker,
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DailyDiaryListItem.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DailyDiaryListItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -60,7 +61,9 @@ fun DailyDiaryListItem(
             Image(
                 painter = painterResource(id = R.drawable.ic_home_kebab),
                 contentDescription = "go to delete",
-                modifier = Modifier.clickable(onClick = { onShowDiaryDeleteStateChange(true) })
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable(onClick = { onShowDiaryDeleteStateChange(true) })
             )
         }
         if (dailyDiaries.isEmpty()) {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DayItem.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DayItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -51,6 +52,7 @@ fun DayItem(
         verticalArrangement = Arrangement.Center,
         modifier = modifier
             .padding(8.dp)
+            .clip(RoundedCornerShape(12.dp))
             .clickable { onDayClick(date) }
     ) {
         Box(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/component/YearAndMonthTitle.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/component/YearAndMonthTitle.kt
@@ -2,11 +2,13 @@ package com.sopt.clody.presentation.ui.home.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -23,7 +25,11 @@ fun YearAndMonthTitle(
 
     Column {
         Row(
-            modifier = Modifier.clickable( onClick = { onShowYearMonthPickerStateChange(true)})
+            modifier = Modifier.clickable(
+                onClick = { onShowYearMonthPickerStateChange(true)},
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            )
         ) {
             Text(
                 text = text,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/AccountManagementLogoutOption.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/AccountManagementLogoutOption.kt
@@ -2,6 +2,7 @@ package com.sopt.clody.presentation.ui.setting.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -39,7 +41,11 @@ fun AccountManagementLogoutOption(
         Spacer(modifier = Modifier.weight(1f))
         Text(
             text = stringResource(R.string.account_management_logout_button),
-            modifier = Modifier.clickable(onClick = { updateLogoutDialog(true) }),
+            modifier = Modifier.clickable(
+                onClick = { updateLogoutDialog(true) },
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
             color = ClodyTheme.colors.gray05,
             style = ClodyTheme.typography.body4Medium
         )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/AccountManagementNicknameOption.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/AccountManagementNicknameOption.kt
@@ -2,12 +2,14 @@ package com.sopt.clody.presentation.ui.setting.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -40,7 +42,11 @@ fun AccountManagementNicknameOption(
         Spacer(modifier = Modifier.weight(1f))
         Text(
             text = stringResource(R.string.account_management_nickname_change_button),
-            modifier = Modifier.clickable(onClick = { updateNicknameChangeBottomSheet(true) }),
+            modifier = Modifier.clickable(
+                onClick = { updateNicknameChangeBottomSheet(true) },
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
             color = ClodyTheme.colors.gray05,
             style = ClodyTheme.typography.body4Medium
         )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/AccountManagementRevokeOption.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/AccountManagementRevokeOption.kt
@@ -1,11 +1,13 @@
 package com.sopt.clody.presentation.ui.setting.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -27,7 +29,11 @@ fun AccountManagementRevokeOption(
         Spacer(modifier = Modifier.weight(1f))
         Text(
             text = stringResource(R.string.account_management_revoke_button),
-            modifier = Modifier.clickable(onClick = { updateRevokeDialog(true) }),
+            modifier = Modifier.clickable(
+                onClick = { updateRevokeDialog(true) },
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
             color = ClodyTheme.colors.gray05,
             style = ClodyTheme.typography.body4Medium
         )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/NicknameChangeTextField.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/component/NicknameChangeTextField.kt
@@ -3,6 +3,7 @@ package com.sopt.clody.presentation.ui.setting.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
@@ -78,7 +80,11 @@ fun NickNameChangeTextField(
                         }
                         Box(
                             modifier = Modifier
-                                .clickable { onRemove() },
+                                .clickable(
+                                    onClick = onRemove,
+                                    indication = null,
+                                    interactionSource = remember { MutableInteractionSource() }
+                                ),
                             contentAlignment = Alignment.Center
                         ) {
                             Image(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/bottomsheet/DeleteWriteDiaryBottomSheet.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/bottomsheet/DeleteWriteDiaryBottomSheet.kt
@@ -3,6 +3,7 @@ package com.sopt.clody.presentation.ui.writediary.component.bottomsheet
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,11 +46,14 @@ fun DeleteWriteDiaryBottomSheet(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable {
-                            onDeleteConfirm()
-                            onDismissRequest()
-                        }
+                        .clickable(
+                            onClick = {
+                                onDeleteConfirm()
+                                onDismissRequest()
+                            },
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        )
                         .background(ClodyTheme.colors.white)
                         .padding(start = 24.dp)
                 ) {


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #172 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
**`"온보딩 > 닉네임 설정"`**

1. **텍스트 필드 x 표시**
변경 전 : 사각형 리플
변경 후 : 리플 제거

**`"온보딩 > 알림 설정"`**

1. **다음에 설정할래요**
변경 전 : 타원형 리플 (좀 꽉 낌)
변경 후 : 리플 제거

**`"홈(캘린더)"`**

1. **상단바 리스트,설정 아이콘**
변경 전 : 동그라미 리플 (IconButton 기본)
변경 후 : 유지
2. **연,월 피커**
변경 전 : 사각형 리플
변경 후 : 리플 제거
3. **DayItem(캘린더 일자)**
변경 전 : 사각형 리플
변경 후 : 동그라미 리플
4. **일기 삭제 케밥 메뉴**
변경 전 : 사각형 리플
변경 후 : 동그라미 리플

**`"일기 작성"`**

1. **삭제하기 모달 창**
변경 전 : 둥그런 직사각형인데 화면 전체 너비
변경 후 : 제거

**`"일기 모아보기"`**

1. **연,월 피커**
변경 전 : 사각형 리플
변경 후 : 리플 제거
2. **일기 삭제 케밥 메뉴**
변경 전 : 사각형 리플
변경 후 : 동그라미 리플
3. **삭제하기 모달 창**
변경 전 : 둥그런 직사각형인데 화면 전체 너비
변경 후 : 제거

**`"설정 > 프로필 및 계정 관리"`**

1. **변경하기,로그아웃,회원탈퇴**
변경 전 : 사각형 리플
변경 후 : 제거
2. **닉네임 변경 텍스트 필드 x 버튼**
변경 전 : 사각형 리플
변경 후 : 제거


## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- "다음에 설정할래요" 부분이 TextButton 컴포넌트로 되어 있어 리플 효과 제거가 불가능하여, Text 컴포넌트로 변경했습니다.
-  의도하지 않았는데 이상하다? 하는 제거하는 방향으로 진행했습니다 (ex. 일기삭제 바텀시트 클릭효과)
