### PR TITLE
[FEAT/#179] "설정 > 프로필 및 계정관리" 에러대응

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/diarylist/screen/DiaryListScreen.kt
@@ -47,14 +47,10 @@ fun DiaryListRoute(
         diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
     }
 
-    when (diaryDeleteState) {
-        is DiaryDeleteState.Success -> {
-            LaunchedEffect(Unit) {
-                diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
-            }
+    LaunchedEffect(diaryDeleteState) {
+        if (diaryDeleteState is DiaryDeleteState.Success) {
+            diaryListViewModel.fetchMonthlyDiary(selectedYearInDiaryList, selectedMonthInDiaryList)
         }
-
-        else -> {}
     }
 
     DiaryListScreen(

--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/AccountManagementScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/screen/AccountManagementScreen.kt
@@ -21,6 +21,7 @@ import com.sopt.clody.R
 import com.sopt.clody.presentation.ui.component.FailureScreen
 import com.sopt.clody.presentation.ui.component.LoadingScreen
 import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
+import com.sopt.clody.presentation.ui.component.dialog.FailureDialog
 import com.sopt.clody.presentation.ui.component.toast.ClodyToastMessage
 import com.sopt.clody.presentation.ui.setting.component.AccountManagementLogoutOption
 import com.sopt.clody.presentation.ui.setting.component.AccountManagementNicknameOption
@@ -39,13 +40,15 @@ fun AccountManagementRoute(
 ) {
     val userInfoState by accountManagementViewModel.userInfoState.collectAsState()
     val userNicknameState by accountManagementViewModel.userNicknameState.collectAsState()
-    val revokeAccountState by accountManagementViewModel.revokeAccountState.collectAsState()
     val logOutState by accountManagementViewModel.logOutState.collectAsState()
+    val revokeAccountState by accountManagementViewModel.revokeAccountState.collectAsState()
     var showNicknameChangeBottomSheet by remember { mutableStateOf(false) }
     val isValidNickname by accountManagementViewModel.isValidNickname.collectAsState()
     val nicknameMessage by accountManagementViewModel.nicknameMessage.collectAsState()
     var showLogoutDialog by remember { mutableStateOf(false) }
     var showRevokeDialog by remember { mutableStateOf(false) }
+    val showFailureDialog by accountManagementViewModel.showFailureDialog.collectAsState()
+    val failureDialogMessage by accountManagementViewModel.failureDialogMessage.collectAsState()
 
     LaunchedEffect(Unit) {
         accountManagementViewModel.fetchUserInfo()
@@ -85,6 +88,8 @@ fun AccountManagementRoute(
         updateLogoutDialog = { state -> showLogoutDialog = state },
         showRevokeDialog = showRevokeDialog,
         updateRevokeDialog = { state -> showRevokeDialog = state },
+        showFailureDialog = showFailureDialog,
+        failureDialogMessage = failureDialogMessage,
         onBackClick = { navigator.navigateBack() }
     )
 }
@@ -102,6 +107,8 @@ fun AccountManagementScreen(
     updateLogoutDialog: (Boolean) -> Unit,
     showRevokeDialog: Boolean,
     updateRevokeDialog: (Boolean) -> Unit,
+    showFailureDialog: Boolean,
+    failureDialogMessage: String,
     onBackClick: () -> Unit
 ) {
     Scaffold(
@@ -143,7 +150,10 @@ fun AccountManagementScreen(
             }
 
             is UserInfoState.Failure -> {
-                FailureScreen()
+                FailureScreen(
+                    message = userInfoState.errorMessage,
+                    confirmAction = { accountManagementViewModel.fetchUserInfo() }
+                )
             }
         }
     }
@@ -158,7 +168,7 @@ fun AccountManagementScreen(
         )
     }
 
-    if(userNicknameState is UserNicknameState.Success) {
+    if (userNicknameState is UserNicknameState.Success) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -197,6 +207,13 @@ fun AccountManagementScreen(
             confirmButtonColor = ClodyTheme.colors.red,
             confirmButtonTextColor = ClodyTheme.colors.white,
             onDismiss = { updateRevokeDialog(false) }
+        )
+    }
+
+    if (showFailureDialog) {
+        FailureDialog(
+            message = failureDialogMessage,
+            onDismiss = { accountManagementViewModel.dismissFailureDialog() }
         )
     }
 }


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #179 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- [x] **[ 뷰 교체 ]** "설정 > 프로필 및 계정관리" 유저 정보 받아오기 실패 시 
- [x] **[ 팝업 ]** "설정 > 프로필 및 계정관리" 닉네임 변경 실패 시 
- [x] **[ 팝업 ]** "설정 > 프로필 및 계정관리" 회원탈퇴 실패 시 


## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 알림설정 기능구현 한 PR을 머지하다가 깃이 꼬여버려서.. 일단 이것만 따로 올리겠습니다
