### PR TITLE
[FEAT/#231] 전날 일기 작성 기능을 구현합니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
         val kakaoApiKey: String = properties.getProperty("kakao.api.key")
         val amplitudeApiKey: String = properties.getProperty("amplitude.api.key")
         buildConfigField("String", "KAKAO_API_KEY", "\"$kakaoApiKey\"")
-        buildConfigField("String","APLITUDE_API_KEY","\"$amplitudeApiKey\"")
+        buildConfigField("String","AMPLITUDE_API_KEY","\"$amplitudeApiKey\"")
         manifestPlaceholders["kakaoRedirectUri"] = "kakao$kakaoApiKey"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -39,10 +39,10 @@ android {
             val localProperties = Properties().apply {
                 load(project.rootProject.file("local.properties").inputStream())
             }
-            storeFile = project.rootProject.file(localProperties.getProperty("storeFile"))
-            storePassword = localProperties.getProperty("storePassword") ?: ""
-            keyAlias = localProperties.getProperty("keyAlias") ?: ""
-            keyPassword = localProperties.getProperty("keyPassword") ?: ""
+//            storeFile = project.rootProject.file(localProperties.getProperty("storeFile"))
+//            storePassword = localProperties.getProperty("storePassword") ?: ""
+//            keyAlias = localProperties.getProperty("keyAlias") ?: ""
+//            keyPassword = localProperties.getProperty("keyPassword") ?: ""
         }
     }
 

--- a/app/src/main/java/com/sopt/clody/data/remote/dto/response/DiaryTimeResponseDto.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/dto/response/DiaryTimeResponseDto.kt
@@ -1,11 +1,13 @@
 package com.sopt.clody.data.remote.dto.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class DiaryTimeResponseDto(
-    val HH: Int,
-    val mm: Int,
-    val ss: Int,
-    val isFirst: Boolean,
+    @SerialName("HH") val HH: Int,
+    @SerialName("mm") val mm: Int,
+    @SerialName("ss") val ss: Int,
+    @SerialName("date") val date: String,
+    @SerialName("isFirst") val isFirst: Boolean,
 )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/bottomsheet/DiaryDeleteSheet.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/bottomsheet/DiaryDeleteSheet.kt
@@ -80,6 +80,5 @@ fun DiaryDeleteBottomSheetItem(
             )
         }
         Spacer(modifier = Modifier.navigationBarsPadding())
-        Spacer(modifier = Modifier.height(60.dp))
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/component/DiaryStateButton.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/component/DiaryStateButton.kt
@@ -12,8 +12,6 @@ import java.time.LocalDate
 @Composable
 fun DiaryStateButton(
     diaryCount: Int,
-    replyStatus: String,
-    isToday: Boolean,
     isDeleted: Boolean,
     year: Int,
     month: Int,
@@ -22,11 +20,15 @@ fun DiaryStateButton(
     onClickReplyDiary: () -> Unit,
 ) {
     val today = LocalDate.now()
-    val isSelectedDateToday = year == today.year && month == today.monthValue && day == today.dayOfMonth
+    val isAvailableDay = year == today.year && month == today.monthValue && (day == today.dayOfMonth || day == today.dayOfMonth - 1)
+
+    val writeDiaryEnabled = diaryCount == 0  && isAvailableDay
+    val writeDiaryDisabled = diaryCount == 0 && !isAvailableDay
+    val checkReplyEnabled = diaryCount != 0 && !isDeleted
+    val checkReplyDisabled = diaryCount != 0 && isDeleted
 
     when {
-
-        isToday && diaryCount == 0 -> {
+        writeDiaryEnabled -> {
             ClodyButton(
                 onClick = { onClickWriteDiary(year, month, day) },
                 text = "일기쓰기",
@@ -37,40 +39,7 @@ fun DiaryStateButton(
             )
         }
 
-        isDeleted && diaryCount != 0 -> {
-            ClodyReplyButton(
-                onClick = onClickReplyDiary,
-                text = "답장확인",
-                enabled = false,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            )
-        }
-
-        diaryCount != 0 && (replyStatus == "UNREADY" || replyStatus == "READY_NOT_READ" || replyStatus == "READY_READ") -> {
-            ClodyReplyButton(
-                onClick = onClickReplyDiary,
-                text = "답장확인",
-                enabled = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            )
-        }
-
-        isSelectedDateToday && diaryCount == 0 && replyStatus == "UNREADY" -> {
-            ClodyButton(
-                onClick = { onClickWriteDiary(year, month, day) },
-                text = "일기쓰기",
-                enabled = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            )
-        }
-
-        !isSelectedDateToday && diaryCount == 0 && replyStatus == "UNREADY" -> {
+        writeDiaryDisabled -> {
             ClodyButton(
                 onClick = { onClickWriteDiary(year, month, day) },
                 text = "일기쓰기",
@@ -81,8 +50,26 @@ fun DiaryStateButton(
             )
         }
 
-        else -> {
+        checkReplyEnabled -> {
+            ClodyReplyButton(
+                onClick = onClickReplyDiary,
+                text = "답장확인",
+                enabled = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+        }
 
+        checkReplyDisabled -> {
+            ClodyReplyButton(
+                onClick = onClickReplyDiary,
+                text = "답장확인",
+                enabled = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -196,8 +196,6 @@ fun HomeScreen(
                     Spacer(modifier = Modifier.height(14.dp))
                     DiaryStateButton(
                         diaryCount = diaryCount,
-                        replyStatus = replyStatus,
-                        isToday = isToday,
                         isDeleted = isDeleted,
                         year = selectedDate.year,
                         month = selectedDate.monthValue,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/replyloading/screen/ReplyLoadingViewModel.kt
@@ -72,8 +72,9 @@ class ReplyLoadingViewModel @Inject constructor(
     private fun handleResult(result: Result<DiaryTimeResponseDto>) {
         result.fold(
             onSuccess = { data ->
+                val diaryWrittenDay = data.date.split("-")
                 val targetDateTime = LocalDateTime.of(
-                    lastYear, lastMonth, lastDate,
+                    diaryWrittenDay[0].toInt(), diaryWrittenDay[1].toInt(), diaryWrittenDay[2].toInt(),
                     data.HH, data.mm, data.ss
                 ).plusMinutes(if (data.isFirst) INITIAL_REMINDER_MINUTES else REGULAR_REMINDER_HOURS * 60)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,9 +34,9 @@
     <string name="guide_page2_subtitle">네잎클로버를 함께 드려요</string>
     <string name="guide_page2_description">하루에 받은 감사의 수가 많을수록\n색이 진한 네잎클로버를 전달해요</string>
 
-    <string name="guide_page3_title">오늘의 일기만</string>
+    <string name="guide_page3_title">오늘과 전날 일기만</string>
     <string name="guide_page3_subtitle">작성할 수 있어요</string>
-    <string name="guide_page3_description">전날이나 다음날의 일기는 작성할 수\n없으니, 잊지 말고 기록해주세요</string>
+    <string name="guide_page3_description">그전이나 다음날의 일기는 작성할 수\n없으니, 잊지 말고 기록해주세요</string>
 
     <string name="guide_page4_title">이제 일기를 써볼까요?</string>
     <string name="guide_page4_subtitle">기다리고 있을게요!</string>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #231 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 홈 캘린더 화면에서 버튼 로직을 개선했습니다. isAvailable은 당일이나 전날일 경우 true 입니다.

>    우선 `일기 쓰기`와 `답장 확인`의 가장 큰 차이점은 **일기가 있느냐 없느냐**이다. 
> 
> - `일기 쓰기` → diaryCount == 0
> - `답장 확인` → diaryCount ≠ 0
> 
> 그다음, `일기 쓰기`의 활성 여부는 **당일 또는 전날**이냐, 그렇지 않느냐이다.
> 
> - `활성` → isAvailableDay
> - `비활성` → !isAvailableDay
> 
> 그다음, `답장 확인`의 활성 여부는 **삭제한 이력이 있느냐 없느냐**이다.
> 
> - `활성`(삭제한 이력 없음, 답장 온전히 확인 가능) → !isDeleted
> - `비활성`(삭제한 이력 있음, 답장 오지않기에 확인 불가능) → isDeleted

- 전날 일기 작성 기능을 구현하였습니다. 타겟팅 타임이 기존에는 리스트뷰나 클로버를 통해 진입한 날짜를 기준으로 설정되어 있었으나, 전날 일기 작성 시 카운트를 위하여 서버 측에 일기가 작성된 날짜 필드를 추가해서 내려달라 요청하였고, 해당 날짜를 기준으로 타겟 타임을 설정하여 구현했습니다.


## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 캘린더 버튼쪽과 일기 타이머 계산 로직 모두 제가 작성한 코드가 아니다보니 분석하고 변경하느라 시간이 조금 걸렸던 것 같습니다. 코드를 한번 보시고 제가 놓친 유즈케이스가 있다면 알려주시면 감사하겠습니다!

## 📸 스크린샷/동영상
https://github.com/user-attachments/assets/7865f977-4a0c-4559-9704-33da6a12a71f



