### PR TITLE
[UI/#263] 4차 스프린트 담당 UI 구현합니다.

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/toast/ClodyToastMessage.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/toast/ClodyToastMessage.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.sopt.clody.ui.theme.CLODYTheme
+import com.sopt.clody.presentation.utils.base.BasePreview
+import com.sopt.clody.presentation.utils.base.ClodyPreview
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.delay
 
@@ -65,10 +65,10 @@ fun ClodyToastMessage(
     }
 }
 
-@Preview
+@ClodyPreview
 @Composable
-fun ClodyToastMessagePreview() {
-    CLODYTheme {
+private fun ClodyToastMessagePreview() {
+    BasePreview {
         ClodyToastMessage(
             message = "이메일 인증이 완료되었어요!",
             iconResId = com.sopt.clody.R.drawable.ic_toast_error,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/toast/ClodyToastMessage.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/toast/ClodyToastMessage.kt
@@ -2,13 +2,14 @@ package com.sopt.clody.presentation.ui.component.toast
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sopt.clody.ui.theme.CLODYTheme
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.coroutines.delay
 
@@ -39,11 +41,15 @@ fun ClodyToastMessage(
 
     Box(
         modifier = modifier
-            .wrapContentHeight()
-            .background(color = backgroundColor, shape = RoundedCornerShape(28.dp))
-            .padding(horizontal = 22.dp, vertical = 16.dp),
+            .height(42.dp)
+            .background(color = backgroundColor, shape = RoundedCornerShape(28.dp)),
+        contentAlignment = Alignment.Center,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(horizontal = 18.dp),
+        ) {
             Image(
                 painter = painterResource(id = iconResId),
                 contentDescription = null,
@@ -61,14 +67,15 @@ fun ClodyToastMessage(
 
 @Preview
 @Composable
-fun PreviewCustomToastMessage() {
-    ClodyToastMessage(
-        message = "토스트 메시지",
-        iconResId = 0,
-        backgroundColor = Color(0xFF000000),
-        contentColor = Color(0xFFFFFFFF),
-        durationMillis = 3000,
-        onDismiss = {},
-        modifier = Modifier,
-    )
+fun ClodyToastMessagePreview() {
+    CLODYTheme {
+        ClodyToastMessage(
+            message = "이메일 인증이 완료되었어요!",
+            iconResId = com.sopt.clody.R.drawable.ic_toast_error,
+            backgroundColor = ClodyTheme.colors.gray01,
+            contentColor = ClodyTheme.colors.white,
+            durationMillis = 3000L,
+            onDismiss = {},
+        )
+    }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/button/AddDiaryEntryFAB.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/button/AddDiaryEntryFAB.kt
@@ -1,0 +1,95 @@
+package com.sopt.clody.presentation.ui.writediary.component.button
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.sopt.clody.R
+import com.sopt.clody.presentation.utils.extension.clickableWithoutRipple
+import com.sopt.clody.ui.theme.ClodyTheme
+
+@Composable
+fun BoxScope.AddDiaryEntryFAB(
+    isKeyboardVisible: Boolean,
+    isMaxReached: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor = if (isMaxReached) ClodyTheme.colors.gray04 else ClodyTheme.colors.gray02
+    val contentColor = ClodyTheme.colors.white
+
+    AnimatedContent(
+        targetState = isKeyboardVisible,
+        transitionSpec = {
+            fadeIn(tween(300)) togetherWith fadeOut(tween(300))
+        },
+        modifier = modifier
+            .align(Alignment.BottomEnd)
+            .imePadding()
+            .padding(end = 24.dp, bottom = 12.dp),
+        label = "FAB Animation",
+    ) { keyboardVisible ->
+        if (keyboardVisible) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(28.dp))
+                    .background(containerColor)
+                    .clickableWithoutRipple(enabled = !isMaxReached) {
+                        onClick()
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_writediary_add),
+                    contentDescription = null,
+                    tint = contentColor,
+                )
+            }
+        } else {
+            Row(
+                modifier = Modifier
+                    .height(42.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(containerColor)
+                    .clickableWithoutRipple(enabled = !isMaxReached) {
+                        onClick()
+                    }
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_writediary_add),
+                    contentDescription = null,
+                    tint = contentColor,
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = "추가하기",
+                    color = contentColor,
+                    style = ClodyTheme.typography.body2SemiBold,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/button/SendButton.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/button/SendButton.kt
@@ -1,0 +1,41 @@
+package com.sopt.clody.presentation.ui.writediary.component.button
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sopt.clody.ui.theme.ClodyTheme
+
+@Composable
+fun SendButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    Box(
+        modifier = modifier
+            .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "보내기",
+            color = if (isPressed) ClodyTheme.colors.gray07 else ClodyTheme.colors.gray01,
+            style = ClodyTheme.typography.body2SemiBold,
+        )
+    }
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/textfield/WriteDiaryTextField.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/textfield/WriteDiaryTextField.kt
@@ -142,14 +142,18 @@ fun WriteDiaryTextField(
                             .onFocusChanged { isFocused = it.isFocused },
                     )
 
-                    IconButton(
-                        onClick = onRemove,
-                        modifier = Modifier.size(28.dp),
-                    ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.ic_writediary_kebab),
-                            contentDescription = "Remove",
-                        )
+                    if (isRemovable) {
+                        IconButton(
+                            onClick = onRemove,
+                            modifier = Modifier.size(28.dp),
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_writediary_kebab),
+                                contentDescription = "Remove",
+                            )
+                        }
+                    } else {
+                        Spacer(modifier = Modifier.size(28.dp))
                     }
                 }
             }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/topbar/WriteDiaryTopBar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/topbar/WriteDiaryTopBar.kt
@@ -1,0 +1,51 @@
+package com.sopt.clody.presentation.ui.writediary.component.topbar
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.sopt.clody.R
+import com.sopt.clody.presentation.ui.writediary.component.button.SendButton
+import com.sopt.clody.ui.theme.ClodyTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WriteDiaryTopBar(
+    modifier: Modifier = Modifier,
+    onClickBack: () -> Unit,
+    onClickSend: () -> Unit,
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+) {
+    TopAppBar(
+        modifier = modifier.fillMaxWidth(),
+        title = {},
+        navigationIcon = {
+            IconButton(onClick = onClickBack) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_nickname_back),
+                    contentDescription = "뒤로가기",
+                    tint = ClodyTheme.colors.gray01,
+                )
+            }
+        },
+        actions = {
+            SendButton(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp),
+                onClick = onClickSend,
+            )
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = ClodyTheme.colors.white,
+        ),
+        windowInsets = windowInsets,
+    )
+}

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
@@ -4,11 +4,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -16,15 +20,16 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.clody.R
 import com.sopt.clody.presentation.ui.component.LoadingScreen
@@ -32,9 +37,11 @@ import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
 import com.sopt.clody.presentation.ui.component.dialog.FailureDialog
 import com.sopt.clody.presentation.ui.component.toast.ClodyToastMessage
 import com.sopt.clody.presentation.ui.writediary.component.bottomsheet.DeleteWriteDiaryBottomSheet
+import com.sopt.clody.presentation.ui.writediary.component.button.AddDiaryEntryFAB
 import com.sopt.clody.presentation.ui.writediary.component.text.DiaryTitleText
 import com.sopt.clody.presentation.ui.writediary.component.textfield.WriteDiaryTextField
 import com.sopt.clody.presentation.ui.writediary.component.tooltip.TooltipIcon
+import com.sopt.clody.presentation.ui.writediary.component.topbar.WriteDiaryTopBar
 import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import com.sopt.clody.presentation.utils.extension.heightForScreenPercentage
 import com.sopt.clody.ui.theme.CLODYTheme
@@ -60,10 +67,7 @@ fun WriteDiaryRoute(
     val showDeleteBottomSheet by viewModel::showDeleteBottomSheet
     val entryToDelete by viewModel::entryToDelete
     val showDialog by viewModel::showDialog
-
-    val allFieldsEmpty by remember(entries) {
-        derivedStateOf { entries.all { it.isEmpty() } }
-    }
+    val showExitDialog by viewModel::showExitDialog
 
     LaunchedEffect(writeDiaryState) {
         when (writeDiaryState) {
@@ -81,10 +85,17 @@ fun WriteDiaryRoute(
         showLimitMessage = showLimitMessage,
         showEmptyFieldsMessage = showEmptyFieldsMessage,
         showDeleteBottomSheet = showDeleteBottomSheet,
-        entryToDelete = entryToDelete,
         showDialog = showDialog,
-        allFieldsEmpty = allFieldsEmpty,
-        onClickBack = navigateToPrevious,
+        showFailureDialog = showFailureDialog,
+        failureMessage = failureMessage,
+        showExitDialog = showExitDialog,
+        onClickBack = {
+            if (entries.any { it.isNotBlank() }) {
+                viewModel.updateShowExitDialog(true)
+            } else {
+                navigateToPrevious()
+            }
+        },
         onClickAdd = viewModel::addEntry,
         onClickRemove = { index ->
             viewModel.setEntryToDeleteIndex(index)
@@ -112,17 +123,16 @@ fun WriteDiaryRoute(
         onDismissDialog = { viewModel.updateShowDialog(false) },
         onDismissLimitMessage = { viewModel.updateShowLimitMessage(false) },
         onDismissEmptyFieldsMessage = { viewModel.updateShowEmptyFieldsMessage(false) },
+        onDismissFailureDialog = { viewModel.resetFailureDialog() },
+        onDismissExitDialog = { viewModel.updateShowExitDialog(false) },
+        onConfirmExitDialog = {
+            viewModel.updateShowExitDialog(false)
+            navigateToPrevious()
+        },
         year = year,
         month = month,
         day = date,
     )
-
-    if (showFailureDialog) {
-        FailureDialog(
-            message = failureMessage,
-            onDismiss = viewModel::resetFailureDialog,
-        )
-    }
 }
 
 @Composable
@@ -133,9 +143,7 @@ fun WriteDiaryScreen(
     showLimitMessage: Boolean,
     showEmptyFieldsMessage: Boolean,
     showDeleteBottomSheet: Boolean,
-    entryToDelete: Int,
     showDialog: Boolean,
-    allFieldsEmpty: Boolean,
     onClickBack: () -> Unit,
     onClickAdd: () -> Unit,
     onClickRemove: (Int) -> Unit,
@@ -147,80 +155,138 @@ fun WriteDiaryScreen(
     onDismissDialog: () -> Unit,
     onDismissLimitMessage: (Boolean) -> Unit,
     onDismissEmptyFieldsMessage: (Boolean) -> Unit,
+    showFailureDialog: Boolean,
+    failureMessage: String,
+    showExitDialog: Boolean,
+    onDismissFailureDialog: () -> Unit,
+    onDismissExitDialog: () -> Unit,
+    onConfirmExitDialog: () -> Unit,
     year: Int,
     month: Int,
     day: Int,
 ) {
     val focusManager = LocalFocusManager.current
+    val density = LocalDensity.current
+    val imeBottom = WindowInsets.ime.getBottom(density)
+    val isKeyboardVisible = imeBottom > 0
 
     Scaffold(
         topBar = {
-
+            WriteDiaryTopBar(
+                onClickBack = onClickBack,
+                onClickSend = onClickComplete,
+            )
         },
         content = { innerPadding ->
-            Column(
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(ClodyTheme.colors.white)
-                    .padding(innerPadding)
-                    .padding(horizontal = 24.dp)
-                    .clickable(
-                        indication = null,
-                        interactionSource = remember { MutableInteractionSource() },
-                    ) { focusManager.clearFocus() },
-                horizontalAlignment = Alignment.CenterHorizontally,
+                    .padding(innerPadding),
             ) {
-                Spacer(modifier = Modifier.heightForScreenPercentage(0.017f))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 24.dp)
+                        .clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() },
+                            onClick = { focusManager.clearFocus() },
+                        ),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    DiaryTitleText(
-                        date = stringResource(R.string.write_diary_month_and_date, month, day),
-                        separator = " ",
-                        day = getDayOfWeek(year, month, day),
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
-                    TooltipIcon(
-                        tooltipsText = stringResource(id = R.string.write_diary_help_message),
-                    )
-                }
-                Spacer(modifier = Modifier.heightForScreenPercentage(0.02f))
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    itemsIndexed(entries, key = { index, _ -> index }) { index, text ->
-                        WriteDiaryTextField(
-                            entryNumber = index + 1,
-                            text = text,
-                            onTextChange = { newText -> onTextChange(index, newText) },
-                            onRemove = { onClickRemove(index) },
-                            isRemovable = entries.size > 1,
-                            maxLength = 50,
-                            showWarning = showWarnings[index],
+                    Spacer(modifier = Modifier.heightForScreenPercentage(0.017f))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        DiaryTitleText(
+                            date = stringResource(R.string.write_diary_month_and_date, month, day),
+                            separator = " ",
+                            day = getDayOfWeek(year, month, day),
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        TooltipIcon(tooltipsText = stringResource(id = R.string.write_diary_help_message))
+                    }
+                    Spacer(modifier = Modifier.heightForScreenPercentage(0.02f))
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        itemsIndexed(entries, key = { index, _ -> index }) { index, text ->
+                            WriteDiaryTextField(
+                                entryNumber = index + 1,
+                                text = text,
+                                onTextChange = { newText -> onTextChange(index, newText) },
+                                onRemove = { onClickRemove(index) },
+                                isRemovable = entries.size > 1,
+                                maxLength = 50,
+                                showWarning = showWarnings[index],
+                            )
+                        }
+                    }
+
+                    if (showDeleteBottomSheet) {
+                        DeleteWriteDiaryBottomSheet(
+                            onDismissRequest = onDismissDelete,
+                            onDeleteConfirm = onConfirmDelete,
+                        )
+                    }
+
+                    if (showDialog) {
+                        ClodyDialog(
+                            onDismiss = onDismissDialog,
+                            titleMassage = stringResource(R.string.write_diary_dialog_title),
+                            descriptionMassage = stringResource(R.string.write_diary_dialog_description),
+                            confirmOption = stringResource(R.string.write_diary_dialog_confirm_option),
+                            dismissOption = stringResource(R.string.write_diary_dialog_dismiss_option),
+                            confirmAction = onConfirmDialog,
+                            confirmButtonColor = ClodyTheme.colors.mainYellow,
+                            confirmButtonTextColor = ClodyTheme.colors.gray01,
+                        )
+                    }
+
+                    if (showFailureDialog) {
+                        FailureDialog(
+                            message = failureMessage,
+                            onDismiss = onDismissFailureDialog,
+                        )
+                    }
+
+                    if (showExitDialog) {
+                        ClodyDialog(
+                            titleMassage = stringResource(R.string.temp_save_dialog_exit_title),
+                            descriptionMassage = stringResource(R.string.temp_save_dialog_exit_description),
+                            confirmOption = stringResource(R.string.temp_save_dialog_exit_confirm),
+                            dismissOption = stringResource(R.string.temp_save_dialog_exit_dismiss),
+                            confirmAction = onConfirmExitDialog,
+                            confirmButtonColor = ClodyTheme.colors.red,
+                            confirmButtonTextColor = ClodyTheme.colors.white,
+                            onDismiss = onDismissExitDialog,
                         )
                     }
                 }
+                AddDiaryEntryFAB(
+                    isKeyboardVisible = isKeyboardVisible,
+                    isMaxReached = entries.size >= 5,
+                    onClick = onClickAdd,
+                )
 
-                if (showDeleteBottomSheet) {
-                    DeleteWriteDiaryBottomSheet(
-                        onDismissRequest = onDismissDelete,
-                        onDeleteConfirm = onConfirmDelete,
-                    )
-                }
-
-                if (showDialog) {
-                    ClodyDialog(
-                        onDismiss = onDismissDialog,
-                        titleMassage = stringResource(R.string.write_diary_dialog_title),
-                        descriptionMassage = stringResource(R.string.write_diary_dialog_description),
-                        confirmOption = stringResource(R.string.write_diary_dialog_confirm_option),
-                        dismissOption = stringResource(R.string.write_diary_dialog_dismiss_option),
-                        confirmAction = onConfirmDialog,
-                        confirmButtonColor = ClodyTheme.colors.mainYellow,
-                        confirmButtonTextColor = ClodyTheme.colors.gray01,
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 12.dp)
+                        .zIndex(1f),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    ShowToastMessages(
+                        showLimitMessage = showLimitMessage,
+                        showEmptyFieldsMessage = showEmptyFieldsMessage,
+                        onShowLimitMessageChange = onDismissLimitMessage,
+                        onShowEmptyFieldsMessageChange = onDismissEmptyFieldsMessage,
+                        modifier = Modifier.imePadding(),
                     )
                 }
             }
@@ -237,28 +303,33 @@ private fun ShowToastMessages(
     showEmptyFieldsMessage: Boolean,
     onShowLimitMessageChange: (Boolean) -> Unit,
     onShowEmptyFieldsMessageChange: (Boolean) -> Unit,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
 ) {
-    if (showLimitMessage) {
-        ClodyToastMessage(
-            message = stringResource(R.string.toast_limit_message),
-            iconResId = R.drawable.ic_toast_error,
-            backgroundColor = ClodyTheme.colors.gray04,
-            contentColor = ClodyTheme.colors.white,
-            durationMillis = 3000,
-            onDismiss = { onShowLimitMessageChange(false) },
-        )
-    }
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (showLimitMessage) {
+            ClodyToastMessage(
+                message = stringResource(R.string.toast_limit_message),
+                iconResId = R.drawable.ic_toast_error,
+                backgroundColor = ClodyTheme.colors.gray04,
+                contentColor = ClodyTheme.colors.white,
+                durationMillis = 3000,
+                onDismiss = { onShowLimitMessageChange(false) },
+            )
+        }
 
-    if (showEmptyFieldsMessage) {
-        ClodyToastMessage(
-            message = stringResource(R.string.toast_empty_fields_message),
-            iconResId = R.drawable.ic_toast_error,
-            backgroundColor = ClodyTheme.colors.gray04,
-            contentColor = ClodyTheme.colors.white,
-            durationMillis = 3000,
-            onDismiss = { onShowEmptyFieldsMessageChange(false) },
-        )
+        if (showEmptyFieldsMessage) {
+            ClodyToastMessage(
+                message = stringResource(R.string.toast_empty_fields_message),
+                iconResId = R.drawable.ic_toast_error,
+                backgroundColor = ClodyTheme.colors.gray04,
+                contentColor = ClodyTheme.colors.white,
+                durationMillis = 3000,
+                onDismiss = { onShowEmptyFieldsMessageChange(false) },
+            )
+        }
     }
 }
 
@@ -273,9 +344,7 @@ private fun WriteDiaryScreenPreview() {
             showLimitMessage = false,
             showEmptyFieldsMessage = false,
             showDeleteBottomSheet = false,
-            entryToDelete = -1,
             showDialog = false,
-            allFieldsEmpty = false,
             onClickBack = {},
             onClickAdd = {},
             onClickRemove = {},
@@ -287,10 +356,15 @@ private fun WriteDiaryScreenPreview() {
             onDismissDialog = {},
             onDismissLimitMessage = {},
             onDismissEmptyFieldsMessage = {},
+            showFailureDialog = false,
+            failureMessage = "",
+            showExitDialog = false,
+            onDismissFailureDialog = {},
+            onDismissExitDialog = {},
+            onConfirmExitDialog = {},
             year = 2023,
             month = 10,
             day = 5,
         )
     }
 }
-

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Scaffold
@@ -222,7 +225,11 @@ fun WriteDiaryScreen(
                     }
                     Spacer(modifier = Modifier.heightForScreenPercentage(0.02f))
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .windowInsetsPadding(
+                                WindowInsets.navigationBars.union(WindowInsets.ime),
+                            ),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         itemsIndexed(entries, key = { index, _ -> index }) { index, text ->

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -47,9 +46,10 @@ import com.sopt.clody.presentation.ui.writediary.component.tooltip.TooltipIcon
 import com.sopt.clody.presentation.ui.writediary.component.topbar.WriteDiaryTopBar
 import com.sopt.clody.presentation.utils.amplitude.AmplitudeConstraints
 import com.sopt.clody.presentation.utils.amplitude.AmplitudeUtils
+import com.sopt.clody.presentation.utils.base.BasePreview
+import com.sopt.clody.presentation.utils.base.ClodyPreview
 import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import com.sopt.clody.presentation.utils.extension.heightForScreenPercentage
-import com.sopt.clody.ui.theme.CLODYTheme
 import com.sopt.clody.ui.theme.ClodyTheme
 
 @Composable
@@ -351,10 +351,10 @@ private fun ShowToastMessages(
     }
 }
 
+@ClodyPreview
 @Composable
-@Preview
 private fun WriteDiaryScreenPreview() {
-    CLODYTheme {
+    BasePreview {
         WriteDiaryScreen(
             isLoading = false,
             entries = listOf("Entry 1", "Entry 2", "Entry 3"),

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
@@ -42,6 +42,8 @@ import com.sopt.clody.presentation.ui.writediary.component.text.DiaryTitleText
 import com.sopt.clody.presentation.ui.writediary.component.textfield.WriteDiaryTextField
 import com.sopt.clody.presentation.ui.writediary.component.tooltip.TooltipIcon
 import com.sopt.clody.presentation.ui.writediary.component.topbar.WriteDiaryTopBar
+import com.sopt.clody.presentation.utils.amplitude.AmplitudeConstraints
+import com.sopt.clody.presentation.utils.amplitude.AmplitudeUtils
 import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import com.sopt.clody.presentation.utils.extension.heightForScreenPercentage
 import com.sopt.clody.ui.theme.CLODYTheme
@@ -52,8 +54,8 @@ fun WriteDiaryRoute(
     year: Int,
     month: Int,
     date: Int,
-    navigateToReplyLoading: (Int, Int, Int) -> Unit,
-    navigateToHome: (Int, Int) -> Unit,
+    navigateToReplyLoading: (year: Int, month: Int, date: Int) -> Unit,
+    navigateToHome: (year: Int, month: Int) -> Unit,
     navigateToPrevious: () -> Unit,
     viewModel: WriteDiaryViewModel = hiltViewModel(),
 ) {
@@ -91,13 +93,18 @@ fun WriteDiaryRoute(
         showExitDialog = showExitDialog,
         onClickBack = {
             if (entries.any { it.isNotBlank() }) {
+                AmplitudeUtils.trackEvent(AmplitudeConstraints.WRITING_DIARY_BACK)
                 viewModel.updateShowExitDialog(true)
             } else {
                 navigateToPrevious()
             }
         },
-        onClickAdd = viewModel::addEntry,
+        onClickAdd = {
+            AmplitudeUtils.trackEvent(AmplitudeConstraints.WRITING_DIARY_ADD_LIST)
+            viewModel.addEntry()
+        },
         onClickRemove = { index ->
+            AmplitudeUtils.trackEvent(AmplitudeConstraints.WRITING_DIARY_DELETE_LIST)
             viewModel.setEntryToDeleteIndex(index)
             viewModel.updateShowDeleteBottomSheet(true)
         },
@@ -115,12 +122,16 @@ fun WriteDiaryRoute(
                 if (entries.size > 1 && entries.any { it.isEmpty() }) {
                     viewModel.updateShowEmptyFieldsMessage(true)
                 } else {
+                    AmplitudeUtils.trackEvent(AmplitudeConstraints.WRITING_DIARY_COMPLETE)
                     viewModel.updateShowDialog(true)
                 }
             }
         },
         onConfirmDialog = { viewModel.writeDiary(year, month, date, entries) },
-        onDismissDialog = { viewModel.updateShowDialog(false) },
+        onDismissDialog = {
+            AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.WRITING_DIARY_NO_COMPLETE)
+            viewModel.updateShowDialog(false)
+        },
         onDismissLimitMessage = { viewModel.updateShowLimitMessage(false) },
         onDismissEmptyFieldsMessage = { viewModel.updateShowEmptyFieldsMessage(false) },
         onDismissFailureDialog = { viewModel.resetFailureDialog() },

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
@@ -1,24 +1,17 @@
 package com.sopt.clody.presentation.ui.writediary.screen
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,15 +21,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.clody.R
 import com.sopt.clody.presentation.ui.component.LoadingScreen
-import com.sopt.clody.presentation.ui.component.button.ClodyButton
 import com.sopt.clody.presentation.ui.component.dialog.ClodyDialog
 import com.sopt.clody.presentation.ui.component.dialog.FailureDialog
 import com.sopt.clody.presentation.ui.component.toast.ClodyToastMessage
@@ -44,10 +35,9 @@ import com.sopt.clody.presentation.ui.writediary.component.bottomsheet.DeleteWri
 import com.sopt.clody.presentation.ui.writediary.component.text.DiaryTitleText
 import com.sopt.clody.presentation.ui.writediary.component.textfield.WriteDiaryTextField
 import com.sopt.clody.presentation.ui.writediary.component.tooltip.TooltipIcon
-import com.sopt.clody.presentation.utils.amplitude.AmplitudeConstraints
-import com.sopt.clody.presentation.utils.amplitude.AmplitudeUtils
 import com.sopt.clody.presentation.utils.extension.getDayOfWeek
 import com.sopt.clody.presentation.utils.extension.heightForScreenPercentage
+import com.sopt.clody.ui.theme.CLODYTheme
 import com.sopt.clody.ui.theme.ClodyTheme
 
 @Composable
@@ -55,11 +45,14 @@ fun WriteDiaryRoute(
     year: Int,
     month: Int,
     date: Int,
-    navigateToReplyLoading: (year: Int, month: Int, date: Int) -> Unit,
-    navigateToHome: (year: Int, month: Int) -> Unit,
+    navigateToReplyLoading: (Int, Int, Int) -> Unit,
+    navigateToHome: (Int, Int) -> Unit,
     navigateToPrevious: () -> Unit,
     viewModel: WriteDiaryViewModel = hiltViewModel(),
 ) {
+    val writeDiaryState by viewModel.writeDiaryState.collectAsState()
+    val showFailureDialog by viewModel.showFailureDialog.collectAsState()
+    val failureMessage by viewModel.failureMessage.collectAsState()
     val entries = viewModel.entries
     val showWarnings = viewModel.showWarnings
     val showLimitMessage by viewModel::showLimitMessage
@@ -67,11 +60,8 @@ fun WriteDiaryRoute(
     val showDeleteBottomSheet by viewModel::showDeleteBottomSheet
     val entryToDelete by viewModel::entryToDelete
     val showDialog by viewModel::showDialog
-    val writeDiaryState by viewModel.writeDiaryState.collectAsState()
-    val showFailureDialog by viewModel.showFailureDialog.collectAsState()
-    val failureMessage by viewModel.failureMessage.collectAsState()
 
-    val allFieldsEmpty by remember {
+    val allFieldsEmpty by remember(entries) {
         derivedStateOf { entries.all { it.isEmpty() } }
     }
 
@@ -85,7 +75,6 @@ fun WriteDiaryRoute(
     }
 
     WriteDiaryScreen(
-        viewModel = viewModel,
         isLoading = writeDiaryState is WriteDiaryState.Loading,
         entries = entries,
         showWarnings = showWarnings,
@@ -93,13 +82,36 @@ fun WriteDiaryRoute(
         showEmptyFieldsMessage = showEmptyFieldsMessage,
         showDeleteBottomSheet = showDeleteBottomSheet,
         entryToDelete = entryToDelete,
-        allFieldsEmpty = allFieldsEmpty,
         showDialog = showDialog,
-        onClickBack = {
-            AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.WRITING_DIARY_BACK)
-            navigateToPrevious()
+        allFieldsEmpty = allFieldsEmpty,
+        onClickBack = navigateToPrevious,
+        onClickAdd = viewModel::addEntry,
+        onClickRemove = { index ->
+            viewModel.setEntryToDeleteIndex(index)
+            viewModel.updateShowDeleteBottomSheet(true)
         },
-        onCompleteClick = { viewModel.writeDiary(year, month, date, entries) },
+        onConfirmDelete = {
+            if (entryToDelete != -1) viewModel.removeEntry(entryToDelete)
+        },
+        onDismissDelete = { viewModel.updateShowDeleteBottomSheet(false) },
+        onTextChange = { index, text ->
+            viewModel.updateEntry(index, text)
+            viewModel.validateEntry(index, text)
+        },
+        onClickComplete = {
+            viewModel.validateEntries()
+            if (showWarnings.all { !it }) {
+                if (entries.size > 1 && entries.any { it.isEmpty() }) {
+                    viewModel.updateShowEmptyFieldsMessage(true)
+                } else {
+                    viewModel.updateShowDialog(true)
+                }
+            }
+        },
+        onConfirmDialog = { viewModel.writeDiary(year, month, date, entries) },
+        onDismissDialog = { viewModel.updateShowDialog(false) },
+        onDismissLimitMessage = { viewModel.updateShowLimitMessage(false) },
+        onDismissEmptyFieldsMessage = { viewModel.updateShowEmptyFieldsMessage(false) },
         year = year,
         month = month,
         day = date,
@@ -108,14 +120,13 @@ fun WriteDiaryRoute(
     if (showFailureDialog) {
         FailureDialog(
             message = failureMessage,
-            onDismiss = { viewModel.resetFailureDialog() },
+            onDismiss = viewModel::resetFailureDialog,
         )
     }
 }
 
 @Composable
 fun WriteDiaryScreen(
-    viewModel: WriteDiaryViewModel,
     isLoading: Boolean,
     entries: List<String>,
     showWarnings: List<Boolean>,
@@ -123,10 +134,19 @@ fun WriteDiaryScreen(
     showEmptyFieldsMessage: Boolean,
     showDeleteBottomSheet: Boolean,
     entryToDelete: Int,
-    allFieldsEmpty: Boolean,
     showDialog: Boolean,
+    allFieldsEmpty: Boolean,
     onClickBack: () -> Unit,
-    onCompleteClick: () -> Unit,
+    onClickAdd: () -> Unit,
+    onClickRemove: (Int) -> Unit,
+    onConfirmDelete: () -> Unit,
+    onDismissDelete: () -> Unit,
+    onTextChange: (Int, String) -> Unit,
+    onClickComplete: () -> Unit,
+    onConfirmDialog: () -> Unit,
+    onDismissDialog: () -> Unit,
+    onDismissLimitMessage: (Boolean) -> Unit,
+    onDismissEmptyFieldsMessage: (Boolean) -> Unit,
     year: Int,
     month: Int,
     day: Int,
@@ -135,88 +155,7 @@ fun WriteDiaryScreen(
 
     Scaffold(
         topBar = {
-            IconButton(
-                onClick = onClickBack,
-                modifier = Modifier
-                    .statusBarsPadding()
-                    .padding(top = 26.dp)
-                    .padding(start = 12.dp),
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_nickname_back),
-                    contentDescription = null,
-                )
-            }
-        },
-        bottomBar = {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .navigationBarsPadding()
-                    .background(Color.Transparent),
-                contentAlignment = Alignment.Center,
-            ) {
-                Column(
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(end = 24.dp)
-                            .padding(bottom = 28.dp),
-                        contentAlignment = Alignment.CenterEnd,
-                    ) {
-                        IconButton(
-                            onClick = {
-                                AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.WRITING_DIARY_ADD_LIST)
-                                if (entries.size < 5) {
-                                    viewModel.addEntry()
-                                }
-                            },
-                            enabled = entries.size < 5,
-                            modifier = Modifier
-                                .background(
-                                    color = if (entries.size < 5) ClodyTheme.colors.gray02 else ClodyTheme.colors.gray06,
-                                    shape = RoundedCornerShape(10.dp),
-                                )
-                                .size(41.dp),
-                        ) {
-                            Image(
-                                painter = painterResource(id = R.drawable.ic_writediary_add),
-                                contentDescription = "Add",
-                            )
-                        }
-                    }
 
-                    ClodyButton(
-                        onClick = {
-                            AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.WRITING_DIARY_COMPLETE)
-                            viewModel.validateEntries()
-                            if (showWarnings.all { !it }) {
-                                if (entries.size > 1 && entries.any { it.isEmpty() }) {
-                                    viewModel.updateShowEmptyFieldsMessage(true)
-                                } else {
-                                    viewModel.updateShowDialog(true)
-                                }
-                            }
-                        },
-                        text = stringResource(R.string.write_diary_confirm_button),
-                        enabled = !allFieldsEmpty,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp)
-                            .padding(bottom = 28.dp),
-                    )
-                }
-
-                ShowToastMessages(
-                    showLimitMessage = showLimitMessage,
-                    showEmptyFieldsMessage = showEmptyFieldsMessage,
-                    onShowLimitMessageChange = { viewModel.updateShowLimitMessage(it) },
-                    onShowEmptyFieldsMessageChange = { viewModel.updateShowEmptyFieldsMessage(it) },
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
         },
         content = { innerPadding ->
             Column(
@@ -252,21 +191,12 @@ fun WriteDiaryScreen(
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    itemsIndexed(
-                        items = entries,
-                        key = { index, _ -> index },
-                    ) { index, text ->
+                    itemsIndexed(entries, key = { index, _ -> index }) { index, text ->
                         WriteDiaryTextField(
                             entryNumber = index + 1,
                             text = text,
-                            onTextChange = { newText ->
-                                viewModel.updateEntry(index, newText)
-                                viewModel.validateEntry(index, newText)
-                            },
-                            onRemove = {
-                                viewModel.setEntryToDeleteIndex(index)
-                                viewModel.updateShowDeleteBottomSheet(true)
-                            },
+                            onTextChange = { newText -> onTextChange(index, newText) },
+                            onRemove = { onClickRemove(index) },
                             isRemovable = entries.size > 1,
                             maxLength = 50,
                             showWarning = showWarnings[index],
@@ -276,27 +206,19 @@ fun WriteDiaryScreen(
 
                 if (showDeleteBottomSheet) {
                     DeleteWriteDiaryBottomSheet(
-                        onDismissRequest = { viewModel.updateShowDeleteBottomSheet(false) },
-                        onDeleteConfirm = {
-                            AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.WRITING_DIARY_DELETE_LIST)
-                            if (entryToDelete != -1) {
-                                viewModel.removeEntry(entryToDelete)
-                            }
-                        },
+                        onDismissRequest = onDismissDelete,
+                        onDeleteConfirm = onConfirmDelete,
                     )
                 }
 
                 if (showDialog) {
                     ClodyDialog(
-                        onDismiss = {
-                            AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.WRITING_DIARY_NO_COMPLETE)
-                            viewModel.updateShowDialog(false)
-                        },
+                        onDismiss = onDismissDialog,
                         titleMassage = stringResource(R.string.write_diary_dialog_title),
                         descriptionMassage = stringResource(R.string.write_diary_dialog_description),
                         confirmOption = stringResource(R.string.write_diary_dialog_confirm_option),
                         dismissOption = stringResource(R.string.write_diary_dialog_dismiss_option),
-                        confirmAction = { onCompleteClick() },
+                        confirmAction = onConfirmDialog,
                         confirmButtonColor = ClodyTheme.colors.mainYellow,
                         confirmButtonTextColor = ClodyTheme.colors.gray01,
                     )
@@ -339,3 +261,36 @@ private fun ShowToastMessages(
         )
     }
 }
+
+@Composable
+@Preview
+private fun WriteDiaryScreenPreview() {
+    CLODYTheme {
+        WriteDiaryScreen(
+            isLoading = false,
+            entries = listOf("Entry 1", "Entry 2", "Entry 3"),
+            showWarnings = listOf(false, true, false),
+            showLimitMessage = false,
+            showEmptyFieldsMessage = false,
+            showDeleteBottomSheet = false,
+            entryToDelete = -1,
+            showDialog = false,
+            allFieldsEmpty = false,
+            onClickBack = {},
+            onClickAdd = {},
+            onClickRemove = {},
+            onConfirmDelete = {},
+            onDismissDelete = {},
+            onTextChange = { _, _ -> },
+            onClickComplete = {},
+            onConfirmDialog = {},
+            onDismissDialog = {},
+            onDismissLimitMessage = {},
+            onDismissEmptyFieldsMessage = {},
+            year = 2023,
+            month = 10,
+            day = 5,
+        )
+    }
+}
+

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryViewModel.kt
@@ -54,6 +54,9 @@ class WriteDiaryViewModel @Inject constructor(
     var showDialog by mutableStateOf(false)
         private set
 
+    var showExitDialog by mutableStateOf(false)
+        private set
+
     fun writeDiary(year: Int, month: Int, day: Int, contents: List<String>) {
         viewModelScope.launch {
             if (!networkUtil.isNetworkAvailable()) {
@@ -160,6 +163,10 @@ class WriteDiaryViewModel @Inject constructor(
 
     fun setEntryToDeleteIndex(index: Int) {
         entryToDelete = index
+    }
+
+    fun updateShowExitDialog(show: Boolean) {
+        showExitDialog = show
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,10 +63,16 @@
     <string name="clover_dialog_confirm_option">확인</string>
 
     <!--일기 작성 다이얼로그-->
-    <string name="write_diary_dialog_title">일기를 저장할까요?</string>
-    <string name="write_diary_dialog_description">저장한 일기는 수정이 어려워요.</string>
-    <string name="write_diary_dialog_confirm_option">저장하기</string>
-    <string name="write_diary_dialog_dismiss_option">아니오</string>
+    <string name="write_diary_dialog_title">일기를 로디에게 보낼까요?</string>
+    <string name="write_diary_dialog_description">보낸 일기는 수정이 어려워요.</string>
+    <string name="write_diary_dialog_confirm_option">보내기</string>
+    <string name="write_diary_dialog_dismiss_option">취소</string>
+
+    <!-- 임시저장 다이얼로그 -->
+    <string name="temp_save_dialog_exit_title">지금까지 쓴 일기를 임시저장할까요?</string>
+    <string name="temp_save_dialog_exit_description">나가기를 누르면 작성 중인 내용이 모두 사라져요.</string>
+    <string name="temp_save_dialog_exit_confirm">나가기</string>
+    <string name="temp_save_dialog_exit_dismiss">임시저장</string>
 
     <!--일기 작성-->
     <string name="write_diary_confirm_button">저장</string>
@@ -74,7 +80,7 @@
 
     <!--토스트메시지-->
     <string name="toast_limit_message">최대 5개까지 작성할 수 있어요.</string>
-    <string name="toast_empty_fields_message">모든 감사 일기 작성이 필요해요.</string>
+    <string name="toast_empty_fields_message">빈 칸을 채워야 보낼 수 있어요.</string>
 
     <!--헬프 메시지-->
     <string name="write_diary_help_message">신조어, 비속어, 이모지 작성은 불가능해요</string>


### PR DESCRIPTION
## 📌 ISSUE
<!--이슈 번호 및 제목을 적어주세요!-->
closed #263 

## 📄 Work Description
<!--어떤 작업을 했는지 작성해주세요!-->
1. ViewModel 제거 및 상태 호이스팅 적용
 - ViewModel을 Screen으로부터 제거하고 Route에서 상태를 관리하도록 리팩토링
 - 책임 분리 및 재사용성을 고려한 구조로 개선

2. FAB 컴포넌트화 및 UI 개선
- AddDiaryEntryFAB 컴포넌트 생성
- 키보드 상태에 따라 FAB의 UI 전환
- 최대 항목 수 도달 시 FAB 클릭 비활성화 및 색상 변경 처리

3. TopBar 컴포넌트 추가
- 하단 버튼 제거 및 “보내기” 버튼이 상단에 추가됨에 따른 TopBar Component 생성

4. ClodyToastMessage 레이아웃 개선
- 여러 개의 Toast 메시지가 동시에 출력될 수 있도록 수직 정렬 구조 도입
- zIndex 고려함

5. WriteDiaryTextField 개선
- 제거 가능 여부에 따라 TrailingIcon을 조건부 렌더링

6. 상태 및 다이얼로그 처리 개선
- 모든 다이얼로그(FailureDialog, ClodyDialog, DeleteWriteDiaryBottomSheet)를 Screen으로 이동하여 Presentation 구조 명확화

## ✨ PR Point
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!! 코드를 넣어도 됩니다!-->
여긴 mavericks 적용 안하고 우선 기존 구조를 유지하겠습니다?


## 📸 ScreenShot/Video
<!--스크린샷이나 영상을 첨부해주세요! 생략 하셔도 무방합니다!-->

https://github.com/user-attachments/assets/d6a29d06-fba0-46c7-985b-6b9ec294bdd2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a floating action button for adding diary entries, adapting its appearance based on keyboard visibility and entry limits.
  - Introduced a send button and a custom top bar with back and send actions for the diary writing screen.
  - Added an exit confirmation dialog when attempting to leave with unsaved entries.
  - Enhanced toast message handling to display multiple messages without overlapping the keyboard.

- **Improvements**
  - Updated diary writing confirmation dialog strings for clearer communication.
  - Improved conditional display of remove icons in diary entry fields.
  - Refined UI layout and keyboard handling for a smoother writing experience.
  - Enhanced toast message styling and alignment for better visibility and consistency.
  - Updated toast message component for consistent vertical alignment and theme-based styling.
  - Improved preview components for toast messages and diary writing screen for better design validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->