### PR TITLE
[FEAT/#270] 임시저장 상태에 따른 분기를 추가합니다.

### DIFF
--- a/app/src/main/java/com/sopt/clody/data/remote/dto/response/DailyDiariesResponseDto.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/dto/response/DailyDiariesResponseDto.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DailyDiariesResponseDto(
     @SerialName("diaries") val diaries: List<Diary>,
+    @SerialName("isDraft") val isDraft: Boolean,
 ) {
     @Serializable
     data class Diary(

--- a/app/src/main/java/com/sopt/clody/data/remote/dto/response/MonthlyCalendarResponseDto.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/dto/response/MonthlyCalendarResponseDto.kt
@@ -1,5 +1,6 @@
 package com.sopt.clody.data.remote.dto.response
 
+import com.sopt.clody.domain.model.ReplyStatus
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +12,7 @@ data class MonthlyCalendarResponseDto(
     @Serializable
     data class Diary(
         @SerialName("diaryCount") val diaryCount: Int,
-        @SerialName("replyStatus") val replyStatus: String,
+        @SerialName("replyStatus") val replyStatus: ReplyStatus,
         @SerialName("isDeleted") val isDeleted: Boolean,
     )
 }

--- a/app/src/main/java/com/sopt/clody/domain/model/ReplyStatus.kt
+++ b/app/src/main/java/com/sopt/clody/domain/model/ReplyStatus.kt
@@ -4,5 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 enum class ReplyStatus {
-    UNREADY, READY_READ, READY_NOT_READ
+    UNREADY, READY_READ, READY_NOT_READ, HAS_DRAFT, INVALID_DRAFT;
+
+    val isUnreadOrNotRead: Boolean
+        get() = this == UNREADY || this == READY_NOT_READ
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/ClodyCalendar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/ClodyCalendar.kt
@@ -72,7 +72,7 @@ fun ClodyCalendar(
                 DailyDiaryListItem(
                     date = selectedDate,
                     dayOfWeek = initialDayOfWeek,
-                    dailyDiaries = state.data.diaries,
+                    dailyDiary = state.data,
                     onShowDiaryDeleteStateChange = onShowDiaryDeleteStateChange,
                 )
             }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DailyDiaryListItem.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DailyDiaryListItem.kt
@@ -30,7 +30,7 @@ import java.time.LocalDate
 fun DailyDiaryListItem(
     date: LocalDate,
     dayOfWeek: DayOfWeek,
-    dailyDiaries: List<DailyDiariesResponseDto.Diary>,
+    dailyDiary: DailyDiariesResponseDto,
     onShowDiaryDeleteStateChange: (Boolean) -> Unit,
 ) {
     Column(
@@ -66,26 +66,44 @@ fun DailyDiaryListItem(
                     .clickable(onClick = { onShowDiaryDeleteStateChange(true) }),
             )
         }
-        if (dailyDiaries.isEmpty()) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(vertical = 44.dp),
-            ) {
-                Text(
-                    text = "아직 감사 일기가 없어요!",
-                    style = ClodyTheme.typography.body3Regular,
-                    color = ClodyTheme.colors.gray05,
-                    textAlign = TextAlign.Center,
-                )
+
+        when {
+            dailyDiary.isDraft -> {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 44.dp),
+                ) {
+                    Text(
+                        text = "임시저장된 일기가 있어요.",
+                        style = ClodyTheme.typography.body3Regular,
+                        color = ClodyTheme.colors.gray05,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
-        } else {
-            dailyDiaries.forEachIndexed { index, diary ->
-                DiaryItem(
-                    index = index + 1,
-                    text = diary.content,
-                )
+
+            dailyDiary.diaries.isEmpty() -> {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 44.dp),
+                ) {
+                    Text(
+                        text = "아직 감사 일기가 없어요!",
+                        style = ClodyTheme.typography.body3Regular,
+                        color = ClodyTheme.colors.gray05,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+
+            else -> {
+                dailyDiary.diaries.forEachIndexed { index, diary ->
+                    DiaryItem(index = index + 1, text = diary.content)
+                }
             }
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DayItem.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/calendar/component/DayItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.sopt.clody.R
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
+import com.sopt.clody.domain.model.ReplyStatus
 import com.sopt.clody.presentation.ui.type.DiaryCloverType
 import com.sopt.clody.ui.theme.ClodyTheme
 import kotlinx.datetime.DayOfWeek
@@ -56,7 +57,7 @@ fun DayItem(
                 painter = painterResource(id = iconRes),
                 contentDescription = "Diary clover icon",
             )
-            if (diaryData.replyStatus == "READY_NOT_READ" && diaryData.diaryCount > 0) {
+            if (diaryData.replyStatus == ReplyStatus.READY_NOT_READ && diaryData.diaryCount > 0) {
                 Image(
                     painter = painterResource(id = R.drawable.ic_home_unread_reply),
                     contentDescription = "Unread replies icon",

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/component/DiaryStateButton.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/component/DiaryStateButton.kt
@@ -7,68 +7,56 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.sopt.clody.presentation.ui.component.button.ClodyButton
 import com.sopt.clody.presentation.ui.component.button.ClodyReplyButton
-import java.time.LocalDate
 
 @Composable
 fun DiaryStateButton(
-    diaryCount: Int,
-    isDeleted: Boolean,
+    hasDraft: Boolean,
+    canWrite: Boolean,
+    canReply: Boolean,
     year: Int,
     month: Int,
     day: Int,
     onClickWriteDiary: (Int, Int, Int) -> Unit,
     onClickReplyDiary: () -> Unit,
 ) {
-    val today = LocalDate.now()
-    val isAvailableDay = year == today.year && month == today.monthValue && (day == today.dayOfMonth || day == today.dayOfMonth - 1)
-
-    val writeDiaryEnabled = diaryCount == 0 && isAvailableDay
-    val writeDiaryDisabled = diaryCount == 0 && !isAvailableDay
-    val checkReplyEnabled = diaryCount != 0 && !isDeleted
-    val checkReplyDisabled = diaryCount != 0 && isDeleted
+    val modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp)
 
     when {
-        writeDiaryEnabled -> {
+        hasDraft -> {
             ClodyButton(
                 onClick = { onClickWriteDiary(year, month, day) },
-                text = "일기쓰기",
+                text = "이어쓰기",
                 enabled = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                modifier = modifier,
             )
         }
 
-        writeDiaryDisabled -> {
-            ClodyButton(
-                onClick = { onClickWriteDiary(year, month, day) },
-                text = "일기쓰기",
-                enabled = false,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            )
-        }
-
-        checkReplyEnabled -> {
+        canReply -> {
             ClodyReplyButton(
                 onClick = onClickReplyDiary,
                 text = "답장확인",
                 enabled = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                modifier = modifier,
             )
         }
 
-        checkReplyDisabled -> {
-            ClodyReplyButton(
-                onClick = onClickReplyDiary,
-                text = "답장확인",
+        canWrite -> {
+            ClodyButton(
+                onClick = { onClickWriteDiary(year, month, day) },
+                text = "일기쓰기",
+                enabled = true,
+                modifier = modifier,
+            )
+        }
+
+        else -> {
+            ClodyButton(
+                onClick = { onClickWriteDiary(year, month, day) },
+                text = "일기쓰기",
                 enabled = false,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                modifier = modifier,
             )
         }
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/navigation/HomeNavigation.kt
@@ -25,9 +25,6 @@ fun NavGraphBuilder.homeScreen(
     composable<Route.Home> { backStackEntry ->
         backStackEntry.toRoute<Route.Home>().apply {
             HomeRoute(
-                selectedYear = selectedYear,
-                selectedMonth = selectedMonth,
-                selectedDay = selectedDay,
                 isFromReplyDiary = isFromReplyDiary,
                 navigateToDiaryList = navigateToDiaryList,
                 navigateToSetting = navigateToSetting,

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sopt.clody.R
 import com.sopt.clody.core.review.InAppReviewManager
+import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
 import com.sopt.clody.domain.model.ReplyStatus
 import com.sopt.clody.presentation.ui.component.FailureScreen
 import com.sopt.clody.presentation.ui.component.LoadingScreen
@@ -47,9 +48,6 @@ import java.time.LocalDate
 
 @Composable
 fun HomeRoute(
-    selectedYear: Int,
-    selectedMonth: Int,
-    selectedDay: Int?,
     isFromReplyDiary: Boolean,
     navigateToDiaryList: (year: Int, month: Int) -> Unit,
     navigateToSetting: () -> Unit,
@@ -64,19 +62,19 @@ fun HomeRoute(
     homeViewModel: HomeViewModel = hiltViewModel(),
 ) {
     val calendarState by homeViewModel.calendarState.collectAsStateWithLifecycle()
-    val dailyDiariesState by homeViewModel.dailyDiariesState.collectAsStateWithLifecycle()
     val replyStatus by homeViewModel.replyStatus.collectAsStateWithLifecycle()
     val showFirstDraftPopup by homeViewModel.showFirstDraftPopup.collectAsStateWithLifecycle()
     val draftAlarmEnableToast by homeViewModel.draftAlarmEnableToast.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val showInAppReviewPopup by homeViewModel.showInAppReviewPopup.collectAsStateWithLifecycle()
-
-    val isError = calendarState is CalendarState.Error || dailyDiariesState is DailyDiariesState.Error
-    val errorMessage = when {
-        calendarState is CalendarState.Error -> (calendarState as CalendarState.Error).message
-        dailyDiariesState is DailyDiariesState.Error -> (dailyDiariesState as DailyDiariesState.Error).message
-        else -> ""
-    }
+    val showContinueDraftDialog by homeViewModel.showContinueDraftDialog.collectAsStateWithLifecycle()
+    val showDiaryDeleteState by homeViewModel.showDiaryDeleteState.collectAsStateWithLifecycle()
+    val showDiaryDeleteDialog by homeViewModel.showDiaryDeleteDialog.collectAsStateWithLifecycle()
+    val selectedDiaryDate by homeViewModel.selectedDiaryDate.collectAsStateWithLifecycle()
+    val selectedDate by homeViewModel.selectedDate.collectAsStateWithLifecycle()
+    val deleteDiaryState by homeViewModel.deleteDiaryState.collectAsStateWithLifecycle()
+    val (isError, errorMessage) = homeViewModel.errorState.collectAsStateWithLifecycle().value
+    val showYearMonthPickerState by homeViewModel.showYearMonthPickerState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.HOME)
@@ -87,36 +85,49 @@ fun HomeRoute(
         }
     }
 
-    LaunchedEffect(selectedYear, selectedMonth, selectedDay) {
-        homeViewModel.refreshCalendarDataCalendarData(selectedYear, selectedMonth)
+    LaunchedEffect(selectedDiaryDate.year, selectedDiaryDate.month, selectedDate.dayOfMonth) {
+        homeViewModel.refreshCalendarDataCalendarData(selectedDiaryDate.year, selectedDiaryDate.month)
 
-        if (selectedDay != null) {
-            homeViewModel.updateSelectedDate(LocalDate.of(selectedYear, selectedMonth, selectedDay))
-            homeViewModel.loadDailyDiariesData(selectedYear, selectedMonth, selectedDay)
+        if (selectedDate.dayOfMonth != 0) {
+            homeViewModel.updateSelectedDate(
+                LocalDate.of(selectedDiaryDate.year, selectedDiaryDate.month, selectedDate.dayOfMonth),
+            )
         } else {
-            val today = LocalDate.now()
-            homeViewModel.updateSelectedDate(today)
-            homeViewModel.loadDailyDiariesData(today.year, today.monthValue, today.dayOfMonth)
+            homeViewModel.updateSelectedDate(LocalDate.now())
         }
     }
-
     if (isError) {
         FailureScreen(
             message = errorMessage,
             confirmAction = {
-                val selectedDate = homeViewModel.selectedDate.value
-                homeViewModel.refreshCalendarDataCalendarData(selectedYear, selectedMonth)
-                homeViewModel.loadDailyDiariesData(selectedYear, selectedMonth, selectedDate.dayOfMonth)
+                homeViewModel.refreshCalendarDataCalendarData(
+                    selectedDiaryDate.year,
+                    selectedDiaryDate.month,
+                )
+                homeViewModel.loadDailyDiariesData(
+                    selectedDiaryDate.year,
+                    selectedDiaryDate.month,
+                    selectedDate.dayOfMonth,
+                )
             },
         )
     } else {
         HomeScreen(
             homeViewModel = homeViewModel,
+            calendarState = calendarState,
+            deleteDiaryState = deleteDiaryState,
+            showYearMonthPickerState = showYearMonthPickerState,
             onClickDiaryList = navigateToDiaryList,
             onClickSetting = navigateToSetting,
             onClickWriteDiary = { year, month, day ->
+                val hasDraft = replyStatus == ReplyStatus.HAS_DRAFT
+                val isValidDraftDate = homeViewModel.isValidDraftDate()
                 AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.HOME_WRITING_DIARY)
-                navigateToWriteDiary(year, month, day)
+                if (hasDraft && isValidDraftDate) {
+                    homeViewModel.setShowContinueDraftDialog(true)
+                } else {
+                    navigateToWriteDiary(year, month, day)
+                }
             },
             onClickReplyDiary = { year, month, day, _ ->
                 AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.HOME_REPLY)
@@ -125,11 +136,17 @@ fun HomeRoute(
                     month,
                     day,
                     Route.ReplyLoading.ReplyLoadingFrom.HOME,
-                    ReplyStatus.valueOf(replyStatus),
+                    replyStatus,
                 )
             },
-            selectedYear = selectedYear,
-            selectedMonth = selectedMonth,
+            isError = isError,
+            errorMessage = errorMessage,
+            selectedYear = selectedDiaryDate.year,
+            selectedMonth = selectedDiaryDate.month,
+            selectedDate = selectedDate,
+            hasDraft = replyStatus == ReplyStatus.HAS_DRAFT,
+            canWrite = homeViewModel.canWriteDiary(),
+            canReply = homeViewModel.canReplyDiary(),
         )
 
         if (showFirstDraftPopup) {
@@ -197,159 +214,24 @@ fun HomeRoute(
                 onDismiss = { homeViewModel.resetDraftAlarmEnableToast() },
             )
         }
-    }
-}
 
-@Composable
-fun HomeScreen(
-    homeViewModel: HomeViewModel,
-    onClickDiaryList: (Int, Int) -> Unit,
-    onClickSetting: () -> Unit,
-    onClickWriteDiary: (Int, Int, Int) -> Unit,
-    onClickReplyDiary: (
-        year: Int,
-        month: Int,
-        date: Int,
-        replyStatus: Route.ReplyLoading.ReplyLoadingFrom,
-    ) -> Unit,
-    selectedYear: Int,
-    selectedMonth: Int,
-) {
-    val (isError, errorMessage) = homeViewModel.errorState.collectAsStateWithLifecycle().value
-
-    if (isError) {
-        FailureScreen(
-            message = errorMessage,
-            confirmAction = {
-                homeViewModel.refreshCalendarDataCalendarData(selectedYear, selectedMonth)
-                val selectedDate = homeViewModel.selectedDate.value
-                homeViewModel.loadDailyDiariesData(selectedYear, selectedMonth, selectedDate.dayOfMonth)
-            },
-        )
-    } else {
-        val selectedDiaryDate by homeViewModel.selectedDiaryDate.collectAsStateWithLifecycle()
-        val selectedDate by homeViewModel.selectedDate.collectAsStateWithLifecycle()
-        val diaryCount by homeViewModel.diaryCount.collectAsStateWithLifecycle()
-        val replyStatus by homeViewModel.replyStatus.collectAsStateWithLifecycle()
-        val isToday by homeViewModel.isToday.collectAsStateWithLifecycle()
-        val isDeleted by homeViewModel.isDeleted.collectAsStateWithLifecycle()
-        val calendarState by homeViewModel.calendarState.collectAsStateWithLifecycle()
-        val deleteDiaryState by homeViewModel.deleteDiaryState.collectAsStateWithLifecycle()
-        val showYearMonthPickerState by homeViewModel.showYearMonthPickerState.collectAsStateWithLifecycle()
-        val showDiaryDeleteState by homeViewModel.showDiaryDeleteState.collectAsStateWithLifecycle()
-        val showDiaryDeleteDialog by homeViewModel.showDiaryDeleteDialog.collectAsStateWithLifecycle()
-
-        var backPressedTime by remember { mutableStateOf(0L) }
-        val backPressThreshold = 2000
-        val context = LocalContext.current
-
-        BackHandler {
-            val currentTime = System.currentTimeMillis()
-            if (currentTime - backPressedTime <= backPressThreshold) {
-                (context as? Activity)?.finish()
-            } else {
-                backPressedTime = currentTime
-            }
-        }
-
-        Scaffold(
-            topBar = {
-                HomeTopAppBar(
-                    onClickDiaryList = {
-                        AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.HOME_LIST_DIARY)
-                        onClickDiaryList(selectedDiaryDate.year, selectedDiaryDate.month)
-                    },
-                    onClickSetting = onClickSetting,
-                    onShowYearMonthPickerStateChange = { newState -> homeViewModel.setShowYearMonthPickerState(newState) },
-                    selectedYear = selectedDiaryDate.year,
-                    selectedMonth = selectedDiaryDate.month,
-                )
-            },
-            containerColor = ClodyTheme.colors.white,
-            content = { innerPadding ->
-                when (val state = calendarState) {
-                    is CalendarState.Idle -> {}
-
-                    is CalendarState.Loading -> {
-                        LoadingScreen()
-                    }
-
-                    is CalendarState.Success -> {
-                        ScrollableCalendar(
-                            selectedYear = selectedDiaryDate.year,
-                            selectedMonth = selectedDiaryDate.month,
-                            cloverCount = state.data.totalCloverCount,
-                            diaries = state.data.diaries,
-                            homeViewModel = homeViewModel,
-                            onShowDiaryDeleteStateChange = { newState -> homeViewModel.setShowDiaryDeleteState(newState) },
-                            selectedDate = selectedDate,
-                            onDiaryDataUpdated = { diaryCount, replyStatus ->
-                                homeViewModel.updateDiaryState(state.data.diaries)
-                            },
-                            modifier = Modifier.padding(innerPadding),
-                        )
-                    }
-
-                    is CalendarState.Error -> {
-                        homeViewModel.setErrorState(true, state.message ?: "알 수 없는 오류가 발생했습니다.")
-                    }
-                }
-
-                when (deleteDiaryState) {
-                    is DeleteDiaryState.Idle -> {}
-
-                    is DeleteDiaryState.Loading -> {
-                        LoadingScreen()
-                    }
-
-                    is DeleteDiaryState.Success -> {
-                    }
-
-                    is DeleteDiaryState.Failure -> {
-                        homeViewModel.setErrorState(true, "일기 삭제 중 오류가 발생했습니다.")
-                    }
-                }
-            },
-            bottomBar = {
-                Column(
-                    modifier = Modifier
-                        .navigationBarsPadding()
-                        .background(ClodyTheme.colors.white),
-                ) {
-                    Spacer(modifier = Modifier.height(14.dp))
-                    DiaryStateButton(
-                        diaryCount = diaryCount,
-                        isDeleted = isDeleted,
-                        year = selectedDate.year,
-                        month = selectedDate.monthValue,
-                        day = selectedDate.dayOfMonth,
-                        onClickWriteDiary = onClickWriteDiary,
-                        onClickReplyDiary = {
-                            onClickReplyDiary(
-                                selectedDate.year,
-                                selectedDate.monthValue,
-                                selectedDate.dayOfMonth,
-                                Route.ReplyLoading.ReplyLoadingFrom.HOME,
-                            )
-                        },
-                    )
-                    Spacer(modifier = Modifier.height(14.dp))
-                }
-            },
-        )
-
-        if (showYearMonthPickerState) {
-            ClodyPopupBottomSheet(onDismissRequest = { homeViewModel.setShowYearMonthPickerState(false) }) {
-                YearMonthPicker(
-                    onDismissRequest = { homeViewModel.setShowYearMonthPickerState(false) },
-                    selectedYear = selectedDiaryDate.year,
-                    selectedMonth = selectedDiaryDate.month,
-                    onYearMonthSelected = { year, month ->
-                        homeViewModel.updateSelectedDiaryDate(DiaryDateData(year, month))
-                        homeViewModel.loadCalendarData(year, month)
-                    },
-                )
-            }
+        if (showContinueDraftDialog) {
+            ClodyDialog(
+                titleMassage = "임시저장된 일기를 이어 쓸까요?",
+                descriptionMassage = "답장 기한이 지나서 답장은 받을 수 없어요.",
+                confirmOption = "이어쓰기",
+                dismissOption = "아니오",
+                confirmAction = {
+                    homeViewModel.setShowContinueDraftDialog(false)
+                    val date = homeViewModel.selectedDate.value
+                    navigateToWriteDiary(date.year, date.monthValue, date.dayOfMonth)
+                },
+                onDismiss = {
+                    homeViewModel.setShowContinueDraftDialog(false)
+                },
+                confirmButtonColor = ClodyTheme.colors.mainYellow,
+                confirmButtonTextColor = ClodyTheme.colors.gray01,
+            )
         }
 
         if (showDiaryDeleteState) {
@@ -383,6 +265,155 @@ fun HomeScreen(
                 confirmButtonColor = ClodyTheme.colors.red,
                 confirmButtonTextColor = ClodyTheme.colors.white,
             )
+        }
+    }
+}
+
+@Composable
+fun HomeScreen(
+    homeViewModel: HomeViewModel,
+    calendarState: CalendarState<MonthlyCalendarResponseDto>,
+    deleteDiaryState: DeleteDiaryState,
+    showYearMonthPickerState: Boolean,
+    onClickDiaryList: (Int, Int) -> Unit,
+    onClickSetting: () -> Unit,
+    onClickWriteDiary: (Int, Int, Int) -> Unit,
+    onClickReplyDiary: (
+        year: Int,
+        month: Int,
+        date: Int,
+        replyStatus: Route.ReplyLoading.ReplyLoadingFrom,
+    ) -> Unit,
+    isError: Boolean,
+    errorMessage: String,
+    selectedYear: Int,
+    selectedMonth: Int,
+    selectedDate: LocalDate,
+    hasDraft: Boolean,
+    canWrite: Boolean,
+    canReply: Boolean,
+) {
+    if (isError) {
+        FailureScreen(
+            message = errorMessage,
+            confirmAction = {
+                homeViewModel.refreshCalendarDataCalendarData(selectedYear, selectedMonth)
+                homeViewModel.loadDailyDiariesData(selectedYear, selectedMonth, selectedDate.dayOfMonth)
+            },
+        )
+    } else {
+        var backPressedTime by remember { mutableStateOf(0L) }
+        val backPressThreshold = 2000
+        val context = LocalContext.current
+
+        BackHandler {
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - backPressedTime <= backPressThreshold) {
+                (context as? Activity)?.finish()
+            } else {
+                backPressedTime = currentTime
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                HomeTopAppBar(
+                    onClickDiaryList = {
+                        AmplitudeUtils.trackEvent(eventName = AmplitudeConstraints.HOME_LIST_DIARY)
+                        onClickDiaryList(selectedYear, selectedMonth)
+                    },
+                    onClickSetting = onClickSetting,
+                    onShowYearMonthPickerStateChange = { newState -> homeViewModel.setShowYearMonthPickerState(newState) },
+                    selectedYear = selectedYear,
+                    selectedMonth = selectedMonth,
+                )
+            },
+            containerColor = ClodyTheme.colors.white,
+            content = { innerPadding ->
+                when (calendarState) {
+                    is CalendarState.Idle -> {}
+
+                    is CalendarState.Loading -> {
+                        LoadingScreen()
+                    }
+
+                    is CalendarState.Success -> {
+                        ScrollableCalendar(
+                            selectedYear = selectedYear,
+                            selectedMonth = selectedMonth,
+                            cloverCount = calendarState.data.totalCloverCount,
+                            diaries = calendarState.data.diaries,
+                            homeViewModel = homeViewModel,
+                            onShowDiaryDeleteStateChange = { newState -> homeViewModel.setShowDiaryDeleteState(newState) },
+                            selectedDate = selectedDate,
+                            onDiaryDataUpdated = { _, _ ->
+                                homeViewModel.updateDiaryState(calendarState.data.diaries)
+                            },
+                            modifier = Modifier.padding(innerPadding),
+                        )
+                    }
+
+                    is CalendarState.Error -> {
+                        homeViewModel.setErrorState(true, calendarState.message ?: "알 수 없는 오류가 발생했습니다.")
+                    }
+                }
+
+                when (deleteDiaryState) {
+                    is DeleteDiaryState.Idle -> {}
+
+                    is DeleteDiaryState.Loading -> {
+                        LoadingScreen()
+                    }
+
+                    is DeleteDiaryState.Success -> {
+                    }
+
+                    is DeleteDiaryState.Failure -> {
+                        homeViewModel.setErrorState(true, "일기 삭제 중 오류가 발생했습니다.")
+                    }
+                }
+            },
+            bottomBar = {
+                Column(
+                    modifier = Modifier
+                        .navigationBarsPadding()
+                        .background(ClodyTheme.colors.white),
+                ) {
+                    Spacer(modifier = Modifier.height(14.dp))
+                    DiaryStateButton(
+                        hasDraft = hasDraft,
+                        canWrite = canWrite,
+                        canReply = canReply,
+                        year = selectedYear,
+                        month = selectedMonth,
+                        day = selectedDate.dayOfMonth,
+                        onClickWriteDiary = onClickWriteDiary,
+                        onClickReplyDiary = {
+                            onClickReplyDiary(
+                                selectedYear,
+                                selectedMonth,
+                                selectedDate.dayOfMonth,
+                                Route.ReplyLoading.ReplyLoadingFrom.HOME,
+                            )
+                        },
+                    )
+                    Spacer(modifier = Modifier.height(14.dp))
+                }
+            },
+        )
+
+        if (showYearMonthPickerState) {
+            ClodyPopupBottomSheet(onDismissRequest = { homeViewModel.setShowYearMonthPickerState(false) }) {
+                YearMonthPicker(
+                    onDismissRequest = { homeViewModel.setShowYearMonthPickerState(false) },
+                    selectedYear = selectedYear,
+                    selectedMonth = selectedMonth,
+                    onYearMonthSelected = { year, month ->
+                        homeViewModel.updateSelectedDiaryDate(DiaryDateData(year, month))
+                        homeViewModel.loadCalendarData(year, month)
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.sopt.clody.data.remote.dto.response.DailyDiariesResponseDto
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
 import com.sopt.clody.data.remote.dto.response.NotificationInfoResponseDto
 import com.sopt.clody.data.remote.util.NetworkUtil
+import com.sopt.clody.domain.model.ReplyStatus
 import com.sopt.clody.domain.repository.DiaryRepository
 import com.sopt.clody.domain.repository.DraftRepository
 import com.sopt.clody.domain.repository.NotificationRepository
@@ -56,8 +57,8 @@ class HomeViewModel @Inject constructor(
     private val _diaryCount = MutableStateFlow(0)
     val diaryCount: StateFlow<Int> get() = _diaryCount
 
-    private val _replyStatus = MutableStateFlow("UNREADY")
-    val replyStatus: StateFlow<String> get() = _replyStatus
+    private val _replyStatus = MutableStateFlow(ReplyStatus.UNREADY)
+    val replyStatus: StateFlow<ReplyStatus> get() = _replyStatus
 
     private val _isToday = MutableStateFlow(false)
     val isToday: StateFlow<Boolean> get() = _isToday
@@ -73,6 +74,9 @@ class HomeViewModel @Inject constructor(
 
     private val _showDiaryDeleteDialog = MutableStateFlow(false)
     val showDiaryDeleteDialog: StateFlow<Boolean> get() = _showDiaryDeleteDialog
+
+    private val _showContinueDraftDialog = MutableStateFlow(false)
+    val showContinueDraftDialog: StateFlow<Boolean> get() = _showContinueDraftDialog
 
     private val _showFirstDraftPopup = MutableStateFlow(draftRepository.getIsFirstUse())
     val showFirstDraftPopup: StateFlow<Boolean> = _showFirstDraftPopup
@@ -159,6 +163,10 @@ class HomeViewModel @Inject constructor(
                 onSuccess = {
                     loadCalendarData(year, month)
                     loadDailyDiariesData(year, month, day)
+                    _diaryCount.value = 0
+                    _isDeleted.value = false
+                    _replyStatus.value = ReplyStatus.UNREADY
+
                     DeleteDiaryState.Success
                 },
                 onFailure = {
@@ -169,7 +177,10 @@ class HomeViewModel @Inject constructor(
     }
 
     fun refreshCalendarDataCalendarData(year: Int, month: Int) {
-        if (calendarState.value is CalendarState.Success && _selectedDiaryDate.value.year == year && _selectedDiaryDate.value.month == month) {
+        if (calendarState.value is CalendarState.Success &&
+            _selectedDiaryDate.value.year == year &&
+            _selectedDiaryDate.value.month == month
+        ) {
             return
         }
         _selectedDiaryDate.value = DiaryDateData(year, month)
@@ -188,7 +199,7 @@ class HomeViewModel @Inject constructor(
     fun updateDiaryState(diaries: List<MonthlyCalendarResponseDto.Diary>) {
         val selectedDiary = diaries.getOrNull(_selectedDate.value.dayOfMonth - 1)
         _diaryCount.value = selectedDiary?.diaryCount ?: 0
-        _replyStatus.value = selectedDiary?.replyStatus ?: "UNREADY"
+        _replyStatus.value = selectedDiary?.replyStatus ?: ReplyStatus.UNREADY
         _isDeleted.value = selectedDiary?.isDeleted ?: false
     }
 
@@ -204,9 +215,30 @@ class HomeViewModel @Inject constructor(
         _showDiaryDeleteDialog.value = state
     }
 
+    fun setShowContinueDraftDialog(state: Boolean) {
+        _showContinueDraftDialog.value = state
+    }
+
     fun updateFirstDraftUse(newState: Boolean) {
         draftRepository.setIsFirstUse(false)
         _showFirstDraftPopup.value = newState
+    }
+
+    fun canWriteDiary(): Boolean {
+        val today = LocalDate.now()
+        val selected = _selectedDate.value
+        val isAvailableDay = selected == today || selected == today.minusDays(1)
+        return _diaryCount.value == 0 && isAvailableDay
+    }
+
+    fun canReplyDiary(): Boolean {
+        return _diaryCount.value > 0 && !_isDeleted.value
+    }
+
+    fun isValidDraftDate(): Boolean {
+        val today = LocalDate.now()
+        val selected = _selectedDate.value
+        return selected == today || selected == today.minusDays(1)
     }
 
     fun enableDraftAlarm(context: Context) {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/ScrollableCalendar.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/ScrollableCalendar.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
+import com.sopt.clody.domain.model.ReplyStatus
 import com.sopt.clody.presentation.ui.home.calendar.ClodyCalendar
 import com.sopt.clody.presentation.ui.home.component.CloverCount
 import com.sopt.clody.ui.theme.ClodyTheme
@@ -26,13 +27,16 @@ fun ScrollableCalendar(
     diaries: List<MonthlyCalendarResponseDto.Diary>,
     onShowDiaryDeleteStateChange: (Boolean) -> Unit,
     selectedDate: LocalDate,
-    onDiaryDataUpdated: (Int, String) -> Unit,
+    onDiaryDataUpdated: (Int, ReplyStatus) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(selectedDate, diaries) {
         if (selectedDate.year == selectedYear && selectedDate.monthValue == selectedMonth) {
             homeViewModel.updateDiaryState(diaries)
-            onDiaryDataUpdated(homeViewModel.diaryCount.value, homeViewModel.replyStatus.value)
+            onDiaryDataUpdated(
+                homeViewModel.diaryCount.value,
+                homeViewModel.replyStatus.value,
+            )
         }
     }
     val scrollState = rememberScrollState()

--- a/app/src/main/java/com/sopt/clody/presentation/ui/type/DiaryCloverType.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/type/DiaryCloverType.kt
@@ -1,29 +1,56 @@
 package com.sopt.clody.presentation.ui.type
 
+import androidx.annotation.DrawableRes
 import com.sopt.clody.R
 import com.sopt.clody.data.remote.dto.response.MonthlyCalendarResponseDto
+import com.sopt.clody.domain.model.ReplyStatus
 
-enum class DiaryCloverType(val iconRes: Int) {
+/**
+ * DiaryData를 기반으로 해당 날짜에 보여줄 클로버 아이콘 타입을 반환.
+ *
+ * - 오늘이고 일기가 없으면 👉 [TODAY_UNWRITTEN]
+ * - 오늘이고 일기와 읽지 않은 답장이 있으면 👉 [TODAY_WRITTEN]
+ * - 임시저장이 존재하면 👉 [DRAFT_SAVED]
+ * - 임시저장이 만료되었으면 👉 [EXPIRED_WRITTEN]
+ * - 일기가 있고 답장이 없거나 읽지 않았으면 👉 [UNGIVEN_CLOVER]
+ * - 일기 수에 따라 👉 [BOTTOM_CLOVER], [MID_CLOVER], [TOP_CLOVER] 구분
+ * - 이 외의 경우 기본값 👉 [UNGIVEN_CLOVER]
+ */
+
+enum class DiaryCloverType(@DrawableRes val iconRes: Int) {
     TODAY_UNWRITTEN(R.drawable.ic_home_today_unwritten_clover),
     TODAY_WRITTEN(R.drawable.ic_home_today_written_clover),
     UNGIVEN_CLOVER(R.drawable.ic_home_ungiven_clover),
     BOTTOM_CLOVER(R.drawable.ic_home_bottom_clover),
     MID_CLOVER(R.drawable.ic_home_mid_clover),
     TOP_CLOVER(R.drawable.ic_home_top_clover),
+    DRAFT_SAVED(R.drawable.ic_home_draft_saved_clover),
+    EXPIRED_WRITTEN(R.drawable.ic_home_expired_written_clover),
     ;
 
     companion object {
-        fun getCalendarCloverType(diaryData: MonthlyCalendarResponseDto.Diary, isToday: Boolean): DiaryCloverType {
+        fun getCalendarCloverType(
+            diaryData: MonthlyCalendarResponseDto.Diary,
+            isToday: Boolean,
+        ): DiaryCloverType {
+            val count = diaryData.diaryCount
+            val reply = diaryData.replyStatus
+
+            val hasDiary = count > 0
+            val noDiary = count == 0
+            val hasDraft = reply == ReplyStatus.HAS_DRAFT
+            val draftExpired = reply == ReplyStatus.INVALID_DRAFT
+            val hasUnreadOrNoReply = reply.isUnreadOrNotRead
+
             return when {
-                isToday && diaryData.diaryCount == 0 -> TODAY_UNWRITTEN
-                isToday && diaryData.diaryCount > 0 &&
-                    (diaryData.replyStatus == "UNREADY" || diaryData.replyStatus == "READY_NOT_READ") -> TODAY_WRITTEN
-                diaryData.replyStatus == "READY_NOT_READ" && diaryData.diaryCount > 0 -> UNGIVEN_CLOVER
-                diaryData.replyStatus == "UNREADY" && diaryData.diaryCount > 0 -> UNGIVEN_CLOVER
-                diaryData.diaryCount == 0 -> UNGIVEN_CLOVER
-                diaryData.diaryCount in 1..2 -> BOTTOM_CLOVER
-                diaryData.diaryCount in 3..4 -> MID_CLOVER
-                diaryData.diaryCount == 5 -> TOP_CLOVER
+                hasDraft -> DRAFT_SAVED
+                isToday && noDiary -> TODAY_UNWRITTEN
+                isToday && hasUnreadOrNoReply -> TODAY_WRITTEN
+                draftExpired -> EXPIRED_WRITTEN
+                hasDiary && hasUnreadOrNoReply -> UNGIVEN_CLOVER
+                count in 1..2 -> BOTTOM_CLOVER
+                count in 3..4 -> MID_CLOVER
+                count >= 5 -> TOP_CLOVER
                 else -> UNGIVEN_CLOVER
             }
         }

--- a/app/src/main/res/drawable/ic_home_draft_saved_clover.xml
+++ b/app/src/main/res/drawable/ic_home_draft_saved_clover.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="25dp"
+    android:viewportWidth="26"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M18.72,0C22.74,0 26,3.134 26,7C26,9.232 24.912,11.218 23.22,12.5C24.912,13.782 26,15.768 26,18C26,21.866 22.74,25 18.72,25C16.398,25 14.332,23.954 12.999,22.327C11.666,23.954 9.601,25 7.28,25C3.26,25 0,21.866 0,18C0,15.768 1.087,13.782 2.779,12.5C1.087,11.218 0,9.232 0,7C0,3.134 3.26,0 7.28,0C9.601,0 11.666,1.046 12.999,2.672C14.332,1.045 16.399,0 18.72,0Z"
+      android:fillColor="#C3C6D0"/>
+  <path
+      android:pathData="M13,12m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:fillColor="#3C3E48"/>
+  <path
+      android:pathData="M8,12m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:fillColor="#3C3E48"/>
+  <path
+      android:pathData="M18,12m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:fillColor="#3C3E48"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_expired_written_clover.xml
+++ b/app/src/main/res/drawable/ic_home_expired_written_clover.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="25dp"
+    android:viewportWidth="26"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M18.72,0C22.74,0 26,3.134 26,7C26,9.232 24.912,11.218 23.22,12.5C24.912,13.782 26,15.768 26,18C26,21.866 22.74,25 18.72,25C16.398,25 14.332,23.954 12.999,22.327C11.666,23.954 9.601,25 7.28,25C3.26,25 0,21.866 0,18C0,15.768 1.087,13.782 2.779,12.5C1.087,11.218 0,9.232 0,7C0,3.134 3.26,0 7.28,0C9.601,0 11.666,1.046 12.999,2.672C14.332,1.045 16.399,0 18.72,0Z"
+      android:fillColor="#9396A2"/>
+</vector>


### PR DESCRIPTION
## 📌 ISSUE
<!--이슈 번호 및 제목을 적어주세요!-->
closed #270 

## 📄 Work Description
<!--어떤 작업을 했는지 작성해주세요!-->
- 약간의 **HomeRoute와 HomeScreen의 구조 리팩토링**
- diaryCount, isDeleted 등의 상태를 직접적으로 비교하는 방식에서, **ReplyStatus enum을 기반으로 hasDraft, canWrite, canReply**를 계산하여 버튼 상태를 분리했습니다.
- navigateToReplyLoading 함수에 ReplyStatus를 문자열이 아닌 **enum으로 안전하게 전달**하도록 수정하였습니다.
- onClickWriteDiary **내부 로직에 임시저장 이어쓰기 다이얼로그 분기 처리** (ReplyStatus.HAS_DRAFT + 날짜 유효성 확인)를 추가하였습니다.
- HomeRoute의 파라미터에서 **selectedYear, selectedMonth, selectedDay를 제거**하고 ViewModel 내부의 selectedDiaryDate 및 selectedDate를 직접 참조하는 구조로 단순화하였습니다.

## ✨ PR Point
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!! 코드를 넣어도 됩니다!-->
구현하면서 나중에 홈 화면 개편하기 쉽게 기존 홈 부분 코드로 약간 리펙토링 했습니다.
다 한거같긴 한데 잘 모르겠음...


## 📸 ScreenShot/Video
<!--스크린샷이나 영상을 첨부해주세요! 생략 하셔도 무방합니다!-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new visual indicators and icons for draft and expired diary states in the calendar.
  - Introduced dialog prompts for continuing draft diaries and confirming diary deletion.
  - Enhanced diary state button with new actions: continue draft, write diary, and check reply, based on diary status.

- **Improvements**
  - Calendar and diary UI now provide clearer feedback on draft, reply, and diary states.
  - State management and error handling are more unified and responsive for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->