### PR TITLE
[REFACTOR/#276] 일기작성 뒤로가기 수정 및 삭제 바텀시트 UI 수정을 진행합니다.

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/bottomsheet/DeleteWriteDiaryBottomSheet.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/component/bottomsheet/DeleteWriteDiaryBottomSheet.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -67,7 +66,6 @@ fun DeleteWriteDiaryBottomSheet(
                     )
                 }
                 Spacer(modifier = Modifier.navigationBarsPadding())
-                Spacer(modifier = Modifier.height(60.dp))
             }
         },
     )

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryScreen.kt
@@ -114,11 +114,11 @@ fun WriteDiaryRoute(
         failureMessage = failureMessage,
         showExitDialog = showExitDialog,
         onClickBack = {
-            if (viewModel.hasChangedFromInitial()) {
-                AmplitudeUtils.trackEvent(AmplitudeConstraints.WRITING_DIARY_BACK)
-                viewModel.updateShowExitDialog(true)
-            } else {
+            AmplitudeUtils.trackEvent(AmplitudeConstraints.WRITING_DIARY_BACK)
+            if (!viewModel.hasChangedFromInitial()) {
                 navigateToPrevious()
+            } else {
+                viewModel.updateShowExitDialog(true)
             }
         },
         onClickAdd = {

--- a/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/writediary/screen/WriteDiaryViewModel.kt
@@ -179,7 +179,10 @@ class WriteDiaryViewModel @Inject constructor(
     }
 
     fun hasChangedFromInitial(): Boolean {
-        return entries != initialEntries
+        if (initialEntries.isEmpty()) return false
+        val current = entries.map { it.trim() }
+        val initial = initialEntries.map { it.trim() }
+        return current != initial
     }
 
     fun fetchDraftDiary(year: Int, month: Int, day: Int) {


### PR DESCRIPTION
## 📌 ISSUE
<!--이슈 번호 및 제목을 적어주세요!-->
closed #276

## 📄 Work Description
<!--어떤 작업을 했는지 작성해주세요!-->
- 뒤로가기 버튼 클릭 시, 일기 내용에 변경이 없을 경우 바로 이전 화면으로 이동하도록 로직 수정
  - hasChangedFromInitial() 함수 내부에서 공백만 있는 입력은 동일한 것으로 간주하도록 트리밍 처리.
- Amplitude 트래킹은 뒤로가기 클릭 시 항상 기록되도록 변경
- 바텀시트 Spacer 제거

## ✨ PR Point
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!! 코드를 넣어도 됩니다!-->
술먹으러 가야지~

## 📸 ScreenShot/Video
<!--스크린샷이나 영상을 첨부해주세요! 생략 하셔도 무방합니다!-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of diary content changes by ignoring whitespace differences.
  - Adjusted exit confirmation logic to ensure event tracking occurs before navigation decisions.

- **Refactor**
  - Removed unnecessary spacing at the bottom of the delete diary confirmation dialog for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->