### PR TITLE
[Chore/#278] 이어쓰기 알림설정 완료 토스트 위치를 수정합니다.

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/home/screen/HomeScreen.kt
@@ -4,8 +4,10 @@ import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -205,13 +207,22 @@ fun HomeRoute(
         }
 
         if (draftAlarmEnableToast) {
-            ClodyToastMessage(
-                message = "이어쓰기 알림 설정을 완료했어요.",
-                iconResId = R.drawable.ic_toast_check_on_18,
-                backgroundColor = ClodyTheme.colors.gray04,
-                contentColor = ClodyTheme.colors.white,
-                durationMillis = 3000,
-                onDismiss = { homeViewModel.resetDraftAlarmEnableToast() },
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.BottomCenter,
+                content = {
+                    ClodyToastMessage(
+                        message = "이어쓰기 알림 설정을 완료했어요.",
+                        iconResId = R.drawable.ic_toast_check_on_18,
+                        backgroundColor = ClodyTheme.colors.gray04,
+                        contentColor = ClodyTheme.colors.white,
+                        durationMillis = 3000,
+                        onDismiss = { homeViewModel.resetDraftAlarmEnableToast() },
+                        modifier = Modifier
+                            .navigationBarsPadding()
+                            .padding(40.dp),
+                    )
+                },
             )
         }
 


### PR DESCRIPTION
## 📌 ISSUE
<!--이슈 번호 및 제목을 적어주세요!-->
closed #278 

## 📄 Work Description
<!--어떤 작업을 했는지 작성해주세요!-->
QA에서 발견된 이어쓰기 알림설정 완료 토스트 위치를 수정합니다.

## ✨ PR Point
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!! 코드를 넣어도 됩니다!-->
빠르게 고쳤읍니다 ㅋㅋ

## 📸 ScreenShot/Video
<!--스크린샷이나 영상을 첨부해주세요! 생략 하셔도 무방합니다!-->
https://github.com/user-attachments/assets/2e448fdd-c0a6-4ae0-a5d2-3032e88e59dd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the positioning and padding of toast messages to ensure they appear at the bottom center of the screen with better spacing and avoid overlap with navigation bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->