### PR TITLE
[Feat/#321] 점검시간 다이얼로그 국제화 및 포맷 수정을 진행합니다.

### DIFF
--- a/app/src/main/java/com/sopt/clody/data/remote/appupdate/AppUpdateCheckerImpl.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/appupdate/AppUpdateCheckerImpl.kt
@@ -33,21 +33,35 @@ class AppUpdateCheckerImpl @Inject constructor(
         }
     }
 
+    /**
+     * Firebase RemoteConfig 로부터 점검 시간에 해당 하는지 검사하는 함수.
+     *
+     * @return 점검 시간 해당 여부
+     * */
     override suspend fun isUnderInspection(): Boolean {
         val start = remoteConfigDataSource.getInspectionStart() ?: return false
         val end = remoteConfigDataSource.getInspectionEnd() ?: return false
-        val serverZone = ZoneId.of("Asia/Seoul")
+        val serverZone = ZoneId.of(SERVER_TIMEZONE)
 
         val nowServer = ZonedDateTime.now(serverZone)
         val startZ = start.atZone(serverZone)
         val endZ = end.atZone(serverZone)
 
-        return nowServer.isAfter(startZ) && nowServer.isBefore(endZ)
+        return nowServer in startZ..endZ
     }
 
+    /**
+     * Firebase RemoteConfig 로부터 점검 시간을 가져와 반환하는 함수.
+     *
+     * @return 점검 시작 시간과 종료 시간을 "2025-08-11T18:00:00" 형식으로 반환
+     * */
     override suspend fun getInspectionTimeText(): Pair<String, String>? {
         val start = remoteConfigDataSource.getInspectionStart() ?: return null
         val end = remoteConfigDataSource.getInspectionEnd() ?: return null
         return start.toString() to end.toString()
+    }
+
+    companion object {
+        private const val SERVER_TIMEZONE = "Asia/Seoul"
     }
 }

--- a/app/src/main/java/com/sopt/clody/data/remote/appupdate/AppUpdateCheckerImpl.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/appupdate/AppUpdateCheckerImpl.kt
@@ -4,7 +4,8 @@ import com.sopt.clody.data.remote.datasource.RemoteConfigDataSource
 import com.sopt.clody.domain.appupdate.AppUpdateChecker
 import com.sopt.clody.domain.model.AppUpdateState
 import com.sopt.clody.domain.util.VersionComparator
-import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import javax.inject.Inject
 
 class AppUpdateCheckerImpl @Inject constructor(
@@ -35,17 +36,18 @@ class AppUpdateCheckerImpl @Inject constructor(
     override suspend fun isUnderInspection(): Boolean {
         val start = remoteConfigDataSource.getInspectionStart() ?: return false
         val end = remoteConfigDataSource.getInspectionEnd() ?: return false
-        val now = LocalDateTime.now()
-        return now.isAfter(start) && now.isBefore(end)
+        val serverZone = ZoneId.of("Asia/Seoul")
+
+        val nowServer = ZonedDateTime.now(serverZone)
+        val startZ = start.atZone(serverZone)
+        val endZ = end.atZone(serverZone)
+
+        return nowServer.isAfter(startZ) && nowServer.isBefore(endZ)
     }
 
     override suspend fun getInspectionTimeText(): Pair<String, String>? {
-        val start = remoteConfigDataSource.getInspectionStart()
-        val end = remoteConfigDataSource.getInspectionEnd()
-        if (start == null || end == null) return null
-
-        val startText = start.toString()
-        val endText = end.toString()
-        return startText to endText
+        val start = remoteConfigDataSource.getInspectionStart() ?: return null
+        val end = remoteConfigDataSource.getInspectionEnd() ?: return null
+        return start.toString() to end.toString()
     }
 }

--- a/app/src/main/java/com/sopt/clody/data/remote/appupdate/AppUpdateCheckerImpl.kt
+++ b/app/src/main/java/com/sopt/clody/data/remote/appupdate/AppUpdateCheckerImpl.kt
@@ -5,8 +5,6 @@ import com.sopt.clody.domain.appupdate.AppUpdateChecker
 import com.sopt.clody.domain.model.AppUpdateState
 import com.sopt.clody.domain.util.VersionComparator
 import java.time.LocalDateTime
-import java.time.format.TextStyle
-import java.util.Locale
 import javax.inject.Inject
 
 class AppUpdateCheckerImpl @Inject constructor(
@@ -41,22 +39,13 @@ class AppUpdateCheckerImpl @Inject constructor(
         return now.isAfter(start) && now.isBefore(end)
     }
 
-    override fun getInspectionTimeText(): String? {
+    override suspend fun getInspectionTimeText(): Pair<String, String>? {
         val start = remoteConfigDataSource.getInspectionStart()
         val end = remoteConfigDataSource.getInspectionEnd()
         if (start == null || end == null) return null
 
-        val startText = formatDateTimeWithDayOfWeek(start)
-        val endText = formatDateTimeWithDayOfWeek(end)
-        return "$startText ~ $endText"
-    }
-
-    private fun formatDateTimeWithDayOfWeek(dateTime: LocalDateTime): String {
-        val dayOfWeek = dateTime.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN)
-        val month = dateTime.monthValue
-        val day = dateTime.dayOfMonth
-        val hour = dateTime.hour.toString().padStart(2, '0')
-
-        return "$month/$day($dayOfWeek) ${hour}시"
+        val startText = start.toString()
+        val endText = end.toString()
+        return startText to endText
     }
 }

--- a/app/src/main/java/com/sopt/clody/domain/appupdate/AppUpdateChecker.kt
+++ b/app/src/main/java/com/sopt/clody/domain/appupdate/AppUpdateChecker.kt
@@ -5,5 +5,5 @@ import com.sopt.clody.domain.model.AppUpdateState
 interface AppUpdateChecker {
     suspend fun getAppUpdateState(currentVersion: String): AppUpdateState
     suspend fun isUnderInspection(): Boolean
-    fun getInspectionTimeText(): String?
+    suspend fun getInspectionTimeText(): Pair<String, String>?
 }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/component/dialog/InspectionDialog.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/component/dialog/InspectionDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -63,14 +64,14 @@ fun InspectionDialog(
                     )
                     Spacer(modifier = Modifier.height(20.dp))
                     Text(
-                        text = "보다 안정적인 클로디 서비스를 위해\n시스템 점검 중이에요. 곧 다시 만나요!",
+                        text = stringResource(R.string.dialog_inspection_title),
                         color = ClodyTheme.colors.gray03,
                         textAlign = TextAlign.Center,
                         style = ClodyTheme.typography.body3Medium,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "점검시간 : $inspectionTime",
+                        text = stringResource(R.string.dialog_inspection_description, inspectionTime),
                         color = ClodyTheme.colors.gray04,
                         textAlign = TextAlign.Center,
                         style = ClodyTheme.typography.body3Medium,
@@ -84,7 +85,7 @@ fun InspectionDialog(
                         colors = ButtonDefaults.buttonColors(ClodyTheme.colors.mainYellow),
                     ) {
                         Text(
-                            text = "확인",
+                            text = stringResource(R.string.dialog_inspection_confirm),
                             color = ClodyTheme.colors.gray02,
                             style = ClodyTheme.typography.body3SemiBold,
                         )
@@ -100,7 +101,7 @@ fun InspectionDialog(
 private fun PreviewInspectionDialog() {
     BasePreview {
         InspectionDialog(
-            inspectionTime = "",
+            inspectionTime = "Dec 14 (Wed) 12:00 PM ~ Mar 15 (Wed) 10:00 PM",
             onDismiss = {},
         )
     }

--- a/app/src/main/java/com/sopt/clody/presentation/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/splash/SplashViewModel.kt
@@ -10,6 +10,7 @@ import com.sopt.clody.domain.model.AppUpdateState
 import com.sopt.clody.domain.repository.TokenRepository
 import com.sopt.clody.presentation.utils.amplitude.AmplitudeConstraints
 import com.sopt.clody.presentation.utils.amplitude.AmplitudeUtils
+import com.sopt.clody.presentation.utils.language.LanguageProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -25,6 +26,7 @@ class SplashViewModel @AssistedInject constructor(
     @Assisted initialState: SplashContract.SplashState,
     private val tokenRepository: TokenRepository,
     private val appUpdateChecker: AppUpdateChecker,
+    private val languageProvider: LanguageProvider,
 ) : MavericksViewModel<SplashContract.SplashState>(initialState) {
 
     private val _intents = Channel<SplashContract.SplashIntent>(BUFFERED)
@@ -64,7 +66,10 @@ class SplashViewModel @AssistedInject constructor(
 
     private suspend fun checkInspectionAndHandle(): Boolean {
         if (appUpdateChecker.isUnderInspection()) {
-            val inspectionText = appUpdateChecker.getInspectionTimeText()
+            val inspectionTextRaw = appUpdateChecker.getInspectionTimeText()
+            val inspectionText = inspectionTextRaw?.let { (start, end) ->
+                languageProvider.getInspectionTimeText(start, end)
+            }
             setState {
                 copy(
                     showInspectionDialog = true,

--- a/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProvider.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProvider.kt
@@ -5,6 +5,7 @@ import com.sopt.clody.presentation.ui.setting.screen.SettingOptionUrls
 
 interface LanguageProvider {
     fun getCurrentLanguageTag(): String
+    fun getInspectionTimeText(start: String, end: String): String?
     fun getLoginType(): OAuthProvider
     fun getNicknameMaxLength(): Int
     fun getDiaryMaxLength(): Int

--- a/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
@@ -3,6 +3,7 @@ package com.sopt.clody.presentation.utils.language
 import com.sopt.clody.data.datastore.OAuthProvider
 import com.sopt.clody.presentation.ui.setting.screen.SettingOptionUrls
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
@@ -20,15 +21,20 @@ class LanguageProviderImpl @Inject constructor() : LanguageProvider {
             val startLdt = LocalDateTime.parse(start, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
             val endLdt = LocalDateTime.parse(end, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
+            val serverZone = ZoneId.of("Asia/Seoul")
+            val userZone = ZoneId.systemDefault()
+
+            val startUser = startLdt.atZone(serverZone).withZoneSameInstant(userZone)
+            val endUser = endLdt.atZone(serverZone).withZoneSameInstant(userZone)
+
             if (isKorean()) {
                 val koPattern = DateTimeFormatter.ofPattern("M/d(E) HH시mm분", Locale.KOREAN)
-                "${startLdt.format(koPattern)} ~ ${endLdt.format(koPattern)}"
+                "${startUser.format(koPattern)} ~ ${endUser.format(koPattern)}"
             } else {
                 val enDatePattern = DateTimeFormatter.ofPattern("MMM d (EEE)", Locale.ENGLISH)
                 val enTimePattern = DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH)
-
-                val left = "${startLdt.format(enDatePattern)}, ${startLdt.format(enTimePattern)}"
-                val right = "${endLdt.format(enDatePattern)} ${endLdt.format(enTimePattern)}"
+                val left = "${startUser.format(enDatePattern)}, ${startUser.format(enTimePattern)}"
+                val right = "${endUser.format(enDatePattern)} ${endUser.format(enTimePattern)}"
                 "$left ~ $right"
             }
         }.getOrNull()

--- a/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
@@ -2,6 +2,8 @@ package com.sopt.clody.presentation.utils.language
 
 import com.sopt.clody.data.datastore.OAuthProvider
 import com.sopt.clody.presentation.ui.setting.screen.SettingOptionUrls
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 
@@ -12,6 +14,25 @@ class LanguageProviderImpl @Inject constructor() : LanguageProvider {
 
     override fun getCurrentLanguageTag(): String =
         locale.toLanguageTag() // e.g., "ko-KR" or "en-US"
+
+    override fun getInspectionTimeText(start: String, end: String): String? {
+        return runCatching {
+            val startLdt = LocalDateTime.parse(start, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            val endLdt = LocalDateTime.parse(end, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+            if (isKorean()) {
+                val koPattern = DateTimeFormatter.ofPattern("M/d(E) HH시mm분", Locale.KOREAN)
+                "${startLdt.format(koPattern)} ~ ${endLdt.format(koPattern)}"
+            } else {
+                val enDatePattern = DateTimeFormatter.ofPattern("MMM d (EEE)", Locale.ENGLISH)
+                val enTimePattern = DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH)
+
+                val left = "${startLdt.format(enDatePattern)}, ${startLdt.format(enTimePattern)}"
+                val right = "${endLdt.format(enDatePattern)} ${endLdt.format(enTimePattern)}"
+                "$left ~ $right"
+            }
+        }.getOrNull()
+    }
 
     override fun getLoginType(): OAuthProvider =
         if (isKorean()) OAuthProvider.KAKAO else OAuthProvider.GOOGLE

--- a/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
@@ -32,7 +32,7 @@ class LanguageProviderImpl @Inject constructor() : LanguageProvider {
                 "${startUser.format(koPattern)} ~ ${endUser.format(koPattern)}"
             } else {
                 val enDatePattern = DateTimeFormatter.ofPattern("MMM d (EEE)", Locale.ENGLISH)
-                val enTimePattern = DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH)
+                val enTimePattern = DateTimeFormatter.ofPattern("HH:mm", Locale.ENGLISH)
                 val left = "${startUser.format(enDatePattern)}, ${startUser.format(enTimePattern)}"
                 val right = "${endUser.format(enDatePattern)} ${endUser.format(enTimePattern)}"
                 "$left ~ $right"

--- a/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/utils/language/LanguageProviderImpl.kt
@@ -4,6 +4,7 @@ import com.sopt.clody.data.datastore.OAuthProvider
 import com.sopt.clody.presentation.ui.setting.screen.SettingOptionUrls
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
@@ -18,26 +19,27 @@ class LanguageProviderImpl @Inject constructor() : LanguageProvider {
 
     override fun getInspectionTimeText(start: String, end: String): String? {
         return runCatching {
-            val startLdt = LocalDateTime.parse(start, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-            val endLdt = LocalDateTime.parse(end, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-
-            val serverZone = ZoneId.of("Asia/Seoul")
+            val serverZone = ZoneId.of(SERVER_TIMEZONE)
             val userZone = ZoneId.systemDefault()
 
-            val startUser = startLdt.atZone(serverZone).withZoneSameInstant(userZone)
-            val endUser = endLdt.atZone(serverZone).withZoneSameInstant(userZone)
+            val startUser = LocalDateTime.parse(start).atZone(serverZone).withZoneSameInstant(userZone)
+            val endUser = LocalDateTime.parse(end).atZone(serverZone).withZoneSameInstant(userZone)
 
-            if (isKorean()) {
-                val koPattern = DateTimeFormatter.ofPattern("M/d(E) HH시mm분", Locale.KOREAN)
-                "${startUser.format(koPattern)} ~ ${endUser.format(koPattern)}"
-            } else {
-                val enDatePattern = DateTimeFormatter.ofPattern("MMM d (EEE)", Locale.ENGLISH)
-                val enTimePattern = DateTimeFormatter.ofPattern("HH:mm", Locale.ENGLISH)
-                val left = "${startUser.format(enDatePattern)}, ${startUser.format(enTimePattern)}"
-                val right = "${endUser.format(enDatePattern)} ${endUser.format(enTimePattern)}"
-                "$left ~ $right"
-            }
+            formatInspectionTime(startUser, endUser)
         }.getOrNull()
+    }
+
+    private fun formatInspectionTime(startUser: ZonedDateTime, endUser: ZonedDateTime): String {
+        return if (isKorean()) {
+            val koPattern = DateTimeFormatter.ofPattern(INSPECTION_TIME_FORMAT_KO, Locale.KOREAN)
+            "${startUser.format(koPattern)} ~ ${endUser.format(koPattern)}"
+        } else {
+            val enDateFormatter = DateTimeFormatter.ofPattern(INSPECTION_DATE_FORMAT_EN, Locale.ENGLISH)
+            val enTimeFormatter = DateTimeFormatter.ofPattern(INSPECTION_TIME_FORMAT_EN, Locale.ENGLISH)
+            val left = "${startUser.format(enDateFormatter)}, ${startUser.format(enTimeFormatter)}"
+            val right = "${endUser.format(enDateFormatter)} ${endUser.format(enTimeFormatter)}"
+            "$left ~ $right"
+        }
     }
 
     override fun getLoginType(): OAuthProvider =
@@ -53,10 +55,14 @@ class LanguageProviderImpl @Inject constructor() : LanguageProvider {
         if (isKorean()) option.koUrl else option.enUrl
 
     companion object {
-        const val LANGUAGE_KO = "ko"
-        const val NICKNAME_MAX_LENGTH_EN = 15
-        const val NICKNAME_MAX_LENGTH_KO = 10
-        const val DIARY_MAX_LENGTH_EN = 100
-        const val DIARY_MAX_LENGTH_KO = 50
+        private const val LANGUAGE_KO = "ko"
+        private const val SERVER_TIMEZONE = "Asia/Seoul"
+        private const val INSPECTION_TIME_FORMAT_KO = "M/d(E) HH시mm분"
+        private const val INSPECTION_DATE_FORMAT_EN = "MMM d (EEE)"
+        private const val INSPECTION_TIME_FORMAT_EN = "HH:mm"
+        private const val NICKNAME_MAX_LENGTH_EN = 15
+        private const val NICKNAME_MAX_LENGTH_KO = 10
+        private const val DIARY_MAX_LENGTH_EN = 100
+        private const val DIARY_MAX_LENGTH_KO = 50
     }
 }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -159,6 +159,10 @@
     <string name="dialog_revoke_confirm">탈퇴할래요</string>
     <string name="dialog_revoke_dismiss">아니요</string>
 
+    <string name="dialog_inspection_title">보다 안정적인 클로디 서비스를 위해\n시스템 점검 중이에요. 곧 다시 만나요!</string>
+    <string name="dialog_inspection_description">점검시간 : %1$s</string>
+    <string name="dialog_inspection_confirm">확인</string>
+
     <!-- 토스트 메시지 -->
     <string name="toast_home_draft_alarm_enabled">이어쓰기 알림 설정을 완료했어요.</string>
     <string name="toast_write_diary_entry_limit">최대 5개까지 작성할 수 있어요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,10 @@
     <string name="dialog_revoke_confirm">Withdraw</string>
     <string name="dialog_revoke_dismiss">Cancel</string>
 
+    <string name="dialog_inspection_title">We\'re conducting system maintenance\nto improve your experience on Clody.\nSee you again soon!</string>
+    <string name="dialog_inspection_description">[Maintenance Time]\n%1$s</string>
+    <string name="dialog_inspection_confirm">OK</string>
+
     <!-- Usage : Toast Message -->
     <string name="toast_home_draft_alarm_enabled">Continue writing reminders are now on!</string>
     <string name="toast_write_diary_entry_empty">Field required to send.</string>


### PR DESCRIPTION
## 📌 ISSUE
<!--이슈 번호 및 제목을 적어주세요!-->
closed #321 

## 📄 Work Description
<!--어떤 작업을 했는지 작성해주세요!-->
- 점검시간 다이얼로그 string 추출로 국제화
- 분 단위도 나타낼 수 있도록 언어별 포맷 수정
- 점검시간을 유저 타임존에 맞추어 변환

## ✨ PR Point
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!! 코드를 넣어도 됩니다!-->
원래는 remoteConfig에서 가져온 2025-08-11T18:00:00 형식의 점검시간을 가공 후 뷰모델로 넘겨주었는데
언어 분기 처리를 위한 LanguageProvider 때문에 layer간 의존성이 역전되어,, 방식을 조금 변경했습니다.
1. data layer (AppUpdateChecker) 에서는 raw한 형태로 fetch 하여 전달하는 역할만 합니다.
2. 뷰모델에서 시작시간/종료시간을 받은 후 LanguageProvider에 넘깁니다
3. LanguageProvider에서 언어별, 타임존별로 알맞은 포맷으로 가공합니다.

## 📸 ScreenShot/Video
<!--스크린샷이나 영상을 첨부해주세요! 생략 하셔도 무방합니다!-->
<img width="394" height="384" alt="스크린샷 2025-08-14 22 41 17" src="https://github.com/user-attachments/assets/5904f76e-465e-4e4f-8964-5d584bc598ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a localized maintenance dialog with dynamic time formatting (supports Korean and English).
  * Splash screen now displays localized maintenance window when applicable.
* Refactor
  * Improved Home screen data loading for more reliable calendar and diary updates; smoother deletion flow.
* Changes
  * Notification permissions: Home screen requests Android 13+ notification permission when needed; Time Reminder no longer prompts for notification permission.
* Chores
  * App version updated to 1.5.0 (build 29).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->