### PR TITLE
[Refactor/#322] 영어버전 알림시간 설정에서 TimePeriod가 바뀌지 않는 문제를 수정합니다.

### DIFF
--- a/app/src/main/java/com/sopt/clody/presentation/ui/setting/notificationsetting/component/NotificationSettingTimePicker.kt
+++ b/app/src/main/java/com/sopt/clody/presentation/ui/setting/notificationsetting/component/NotificationSettingTimePicker.kt
@@ -36,14 +36,21 @@ fun NotificationSettingTimePicker(
     onDismissRequest: () -> Unit,
     onConfirm: (TimePeriod, String, String) -> Unit,
 ) {
-    val amPmItemsLabel = TimePeriod.entries.map { it.getLabel() }
-    val amPmItems = remember { amPmItemsLabel }
+    val amPmEnumItems = listOf(TimePeriod.AM, TimePeriod.PM)
+    val amPmLabelItems = amPmEnumItems.map { it.getLabel() }
+
     val hourItems = remember { (1..12).map { it.toString() } }
     val minuteItems = remember { listOf("00", "10", "20", "30", "40", "50") }
 
-    val amPmPickerState = rememberPickerState()
-    val hourPickerState = rememberPickerState()
-    val minutePickerState = rememberPickerState()
+    val amPmPickerState = rememberPickerState().apply {
+        selectedItem = amPmLabelItems[1]
+    }
+    val hourPickerState = rememberPickerState().apply {
+        selectedItem = "9"
+    }
+    val minutePickerState = rememberPickerState().apply {
+        selectedItem = "30"
+    }
 
     Surface(
         modifier = Modifier
@@ -105,7 +112,7 @@ fun NotificationSettingTimePicker(
                     Spacer(Modifier.weight(1f))
                     ClodyPicker(
                         state = amPmPickerState,
-                        items = amPmItems,
+                        items = amPmLabelItems,
                         startIndex = 1,
                         visibleItemsCount = 3,
                         infiniteScroll = false,
@@ -138,8 +145,12 @@ fun NotificationSettingTimePicker(
             }
             ClodyButton(
                 onClick = {
-                    val selectedPeriod = if (amPmPickerState.selectedItem == "오전") TimePeriod.AM else TimePeriod.PM
-                    onConfirm(selectedPeriod, hourPickerState.selectedItem, minutePickerState.selectedItem)
+                    val selectedLabel = amPmPickerState.selectedItem
+                    val selectedPeriod = amPmEnumItems.getOrElse(amPmLabelItems.indexOf(selectedLabel)) { TimePeriod.PM }
+                    val selectedHour = hourPickerState.selectedItem
+                    val selectedMinute = minutePickerState.selectedItem
+
+                    onConfirm(selectedPeriod, selectedHour, selectedMinute)
                 },
                 text = stringResource(R.string.bottom_sheet_notification_time_change_confirm),
                 enabled = true,


### PR DESCRIPTION
## 📌 ISSUE
<!--이슈 번호 및 제목을 적어주세요!-->
closed #322 

## 📄 Work Description
<!--어떤 작업을 했는지 작성해주세요!-->
- 영어버전 알림시간 설정에서 TimePeriod가 바뀌지 않는 문제를 수정

## ✨ PR Point
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!! 코드를 넣어도 됩니다!-->
바보같이 TimePeriod를 검사하는 로직에 "오전" 이라고 하드코딩을 박아놔서 ... 영어 버전에선 바뀌지 않는 이슈가 발생했네요.
온보딩 TimeReminderScreen 에서 사용되는 TimePicker와 동일한 로직으로 변경했습니다. 
예전에 이걸 왜 도대체 따로 만들었는지 모르겠네요 ㅜㅜ 
다음에 TimePicker 로직을 좀 손을 봐야할듯..!

## 📸 ScreenShot/Video
<!--스크린샷이나 영상을 첨부해주세요! 생략 하셔도 무방합니다!-->
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added notification permission prompt on Home (Android 13+).
- Bug Fixes
  - Improved AM/PM selection reliability in notification time picker.
- Refactor
  - Streamlined notification handling: removed extra permission prompt in Time Reminder.
  - Unified and optimized calendar/diary data loading for faster, more responsive updates.
- Chores
  - Bumped app version to 1.5.0 (versionCode 29).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->